### PR TITLE
Remove ResourceNameType for api-common:1.6.0 compat

### DIFF
--- a/plugin/templates/resource_name.mustache
+++ b/plugin/templates/resource_name.mustache
@@ -18,7 +18,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.api.pathtemplate.PathTemplate;
 import {{resourceNameGlobalPackageName}}.ResourceName;
-import {{resourceNameGlobalPackageName}}.ResourceNameType;
 import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
@@ -119,14 +118,6 @@ public class {{className}} {{extensionKeyword}} {{parentInterface}} {
 
   public String getFieldValue(String fieldName) {
     return getFieldValuesMap().get(fieldName);
-  }
-
-  /**
-   * @deprecated This method is only present to satisfy the ResourceName interface.
-   */
-  @Deprecated
-  public ResourceNameType getType() {
-    throw new UnsupportedOperationException("{{className}}.getType() not supported");
   }
 
   @Override

--- a/plugin/templates/resource_name.py
+++ b/plugin/templates/resource_name.py
@@ -32,13 +32,9 @@ from google.gax import path_template
 from plugin.utils import casing_utils
 
 RESOURCE_NAMES_GLOBAL_PACKAGE_JAVA = 'com.google.api.resourcenames'
-RESOURCE_NAMES_TYPE_PACKAGE_JAVA = 'com.google.api.resourcenames.types'
 
 
 class ResourceNameBase(object):
-
-    def resourceNameTypePackageName(self):
-        return RESOURCE_NAMES_TYPE_PACKAGE_JAVA
 
     def resourceNameGlobalPackageName(self):
         return RESOURCE_NAMES_GLOBAL_PACKAGE_JAVA
@@ -247,20 +243,6 @@ class UntypedResourceName(ResourceNameBase):
 
     def package(self):
         return self.untyped_package_name
-
-
-class ResourceNameType(ResourceNameBase):
-
-    def __init__(self, class_name, java_package):
-        self.type_name_upper = casing_utils.get_resource_type_from_class_name(
-            class_name)
-        self.package_name = java_package
-
-    def className(self):
-        return self.type_name_upper
-
-    def package(self):
-        return self.package_name
 
 
 class ResourceNameFixed(ResourceNameBase):

--- a/plugin/templates/resource_name_fixed.mustache
+++ b/plugin/templates/resource_name_fixed.mustache
@@ -15,7 +15,6 @@
 package {{package}};
 
 import {{resourceNameGlobalPackageName}}.ResourceName;
-import {{resourceNameGlobalPackageName}}.ResourceNameType;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 
@@ -50,14 +49,6 @@ public class {{className}} {{extensionKeyword}} {{parentInterface}} {
    */
   public String getFieldValue(String fieldName) {
     return valueMap.get(fieldName);
-  }
-
-  /**
-   * @deprecated This method is only present to satisfy the ResourceName interface.
-   */
-  @Deprecated
-  public ResourceNameType getType() {
-    throw new UnsupportedOperationException("{{className}}.getType() not supported");
   }
 
   @Override

--- a/plugin/templates/untyped_resource_name.mustache
+++ b/plugin/templates/untyped_resource_name.mustache
@@ -16,7 +16,6 @@ package {{package}};
 
 import com.google.common.base.Preconditions;
 import {{resourceNameGlobalPackageName}}.ResourceName;
-import {{resourceNameGlobalPackageName}}.ResourceNameType;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -78,14 +77,6 @@ public class {{className}} {{extensionKeyword}} {{parentInterface}} {
    */
   public String getFieldValue(String fieldName) {
     return valueMap.get(fieldName);
-  }
-
-  /**
-   * @deprecated This method is only present to satisfy the ResourceName interface.
-   */
-  @Deprecated
-  public ResourceNameType getType() {
-    throw new UnsupportedOperationException("{{className}}.getType() not supported");
   }
 
   @Override

--- a/test/testdata/java_archived_book_name.baseline
+++ b/test/testdata/java_archived_book_name.baseline
@@ -18,7 +18,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.api.resourcenames.ResourceName;
-import com.google.api.resourcenames.ResourceNameType;
 import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
@@ -120,14 +119,6 @@ public class ArchivedBookName extends BookName {
 
   public String getFieldValue(String fieldName) {
     return getFieldValuesMap().get(fieldName);
-  }
-
-  /**
-   * @deprecated This method is only present to satisfy the ResourceName interface.
-   */
-  @Deprecated
-  public ResourceNameType getType() {
-    throw new UnsupportedOperationException("ArchivedBookName.getType() not supported");
   }
 
   @Override

--- a/test/testdata/java_deleted_book.baseline
+++ b/test/testdata/java_deleted_book.baseline
@@ -15,7 +15,6 @@
 package com.google.example.library.v1;
 
 import com.google.api.resourcenames.ResourceName;
-import com.google.api.resourcenames.ResourceNameType;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 
@@ -50,14 +49,6 @@ public class DeletedBook implements ResourceName {
    */
   public String getFieldValue(String fieldName) {
     return valueMap.get(fieldName);
-  }
-
-  /**
-   * @deprecated This method is only present to satisfy the ResourceName interface.
-   */
-  @Deprecated
-  public ResourceNameType getType() {
-    throw new UnsupportedOperationException("DeletedBook.getType() not supported");
   }
 
   @Override

--- a/test/testdata/java_shelf_book_name.baseline
+++ b/test/testdata/java_shelf_book_name.baseline
@@ -18,7 +18,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.api.resourcenames.ResourceName;
-import com.google.api.resourcenames.ResourceNameType;
 import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
@@ -120,14 +119,6 @@ public class ShelfBookName extends BookName {
 
   public String getFieldValue(String fieldName) {
     return getFieldValuesMap().get(fieldName);
-  }
-
-  /**
-   * @deprecated This method is only present to satisfy the ResourceName interface.
-   */
-  @Deprecated
-  public ResourceNameType getType() {
-    throw new UnsupportedOperationException("ShelfBookName.getType() not supported");
   }
 
   @Override

--- a/test/testdata/java_shelf_name.baseline
+++ b/test/testdata/java_shelf_name.baseline
@@ -18,7 +18,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.api.resourcenames.ResourceName;
-import com.google.api.resourcenames.ResourceNameType;
 import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
@@ -111,14 +110,6 @@ public class ShelfName implements ResourceName {
 
   public String getFieldValue(String fieldName) {
     return getFieldValuesMap().get(fieldName);
-  }
-
-  /**
-   * @deprecated This method is only present to satisfy the ResourceName interface.
-   */
-  @Deprecated
-  public ResourceNameType getType() {
-    throw new UnsupportedOperationException("ShelfName.getType() not supported");
   }
 
   @Override

--- a/test/testdata/java_untyped_book_name.baseline
+++ b/test/testdata/java_untyped_book_name.baseline
@@ -16,7 +16,6 @@ package com.google.example.library.v1;
 
 import com.google.common.base.Preconditions;
 import com.google.api.resourcenames.ResourceName;
-import com.google.api.resourcenames.ResourceNameType;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -78,14 +77,6 @@ public class UntypedBookName extends BookName {
    */
   public String getFieldValue(String fieldName) {
     return valueMap.get(fieldName);
-  }
-
-  /**
-   * @deprecated This method is only present to satisfy the ResourceName interface.
-   */
-  @Deprecated
-  public ResourceNameType getType() {
-    throw new UnsupportedOperationException("UntypedBookName.getType() not supported");
   }
 
   @Override


### PR DESCRIPTION
api-common:1.6.0 has deleted the ResourceNameType interface, so this PR removes generation of anything referencing ResourceNameType.

Marked WIP until batch regeneration using this PR's changes completes and builds.