### PR TITLE
Use latest pyyaml

### DIFF
--- a/plugin/utils/gapic_utils.py
+++ b/plugin/utils/gapic_utils.py
@@ -34,7 +34,7 @@ GAPIC_CONFIG_ANY = '*'
 
 def read_from_gapic_yaml(yaml_file):
     with open(yaml_file) as f:
-        gapic_yaml = yaml.load(f)
+        gapic_yaml = yaml.load(f, Loader=yaml.FullLoader)
 
     collections = {}
     if 'collections' in gapic_yaml:

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -47,8 +47,8 @@ def pypi_six():
 def pypi_py_yaml():
     http_archive(
         name = "pypi_py_yaml",
-        url = ("https://files.pythonhosted.org/packages/4a/85/db5a2df477072b2902b0eb892feb37d88ac635d36245a72a6a69b23b383a/PyYAML-3.12.tar.gz"),
-        strip_prefix = "PyYAML-3.12/lib",
+        url = ("http://pyyaml.org/download/pyyaml/PyYAML-3.13.tar.gz"),
+        strip_prefix = "PyYAML-3.13/lib",
         build_file_content = _DEFAULT_PY_BUILD_FILE,
     )
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ install_requires = [
     'pystache >= 0.5.4',
     'protobuf >= 3.3',
     'google-gax >= 0.12.3',
-    'pyyaml >= 3.12',
+    'pyyaml >= 3.13',
 ]
 
 setup(


### PR DESCRIPTION
Removes pyyaml warning: https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation