### PR TITLE
Remove explicit fixed resource names

### DIFF
--- a/plugin/utils/gapic_utils.py
+++ b/plugin/utils/gapic_utils.py
@@ -50,14 +50,6 @@ def read_from_gapic_yaml(yaml_file):
     collections = load_collection_configs(single_resource_names, collections)
 
     fixed_collections = {}
-    # TODO(andrealin): Remove the fixed_resource_name_values
-    # parsing once they no longer exist in GAPIC configs.
-    if 'fixed_resource_name_values' in gapic_yaml:
-        fixed_collections = load_fixed_configs(
-            gapic_yaml['fixed_resource_name_values'],
-            fixed_collections,
-            collections,
-            "fixed_value")
     # Add the fixed resource names that are defined in the collections.
     fixed_collections = load_fixed_configs(
         fixed_resource_names,

--- a/test/test_config_parsing.py
+++ b/test/test_config_parsing.py
@@ -53,16 +53,6 @@ class TestConfigParsing(TestCase):
 
     def test_explicit_fixed_name_config_parsing(self):
         gapic_config = gapic_utils.read_from_gapic_yaml(GAPIC_CONFIG_V1_PATH)
-        self.assertEqual(1, len(gapic_config.fixed_collections))
-        self.assertEqual(
-            "deleted_book",
-            gapic_config.fixed_collections['deleted_book'].entity_name)
-        self.assertEqual(
-            "_deleted-book_",
-            gapic_config.fixed_collections['deleted_book'].fixed_value)
-        self.assertEqual(
-            "deleted_book",
-            gapic_config.fixed_collections['deleted_book'].java_entity_name)
 
         self.assertEqual(2, len(gapic_config.collection_configs))
         # Project name won't be included because it is a common resource name.

--- a/test/testdata/library_gapic_v1.yaml
+++ b/test/testdata/library_gapic_v1.yaml
@@ -2,9 +2,6 @@ type: com.google.api.codegen.ConfigProto
 collections:
   - name_pattern: archives/{archive_id}/books/{book_id=**}
     entity_name: archived_book
-fixed_resource_name_values:
-  - entity_name: deleted_book
-    fixed_value: _deleted-book_
 collection_oneofs:
   - oneof_name: book_oneof
     collection_names:


### PR DESCRIPTION
There are now no such things as fixed resource names in GAPIC config v1.