### PR TITLE
Fix Resource Names annotations

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
     sys.exit()
 
-version = '0.0.15'
+version = '0.0.16'
 
 install_requires = [
     'chevron >= 0.13.1',

--- a/test/test_plugin_baseline.py
+++ b/test/test_plugin_baseline.py
@@ -93,8 +93,7 @@ def run_protoc():
     run_protoc_gapic_plugin(TEST_OUTPUT_DIR,
                             gapic_yaml,
                             include_dirs,
-                            [os.path.join(TEST_DIR, x) for x in proto_files],
-                            'java')
+                            [os.path.join(TEST_DIR, x) for x in proto_files])
 
 
 @pytest.fixture(scope='class')
@@ -103,16 +102,20 @@ def run_protoc_v2():
     gapic_yaml = os.path.join(TEST_DIR, 'library_gapic_v2.yaml')
     # TODO: make this path configurable
     include_dirs = ['.', './googleapis']
-    proto_files = ['library_simple.proto', 'archive.proto']
+    proto_files = [
+        'common_resources.proto',
+        'library_simple.proto',
+        'archive.proto'
+    ]
     run_protoc_gapic_plugin(TEST_OUTPUT_DIR,
                             gapic_yaml,
                             include_dirs,
-                            [os.path.join(TEST_DIR, x) for x in proto_files],
-                            'java')
+                            [os.path.join(TEST_DIR, x) for x in proto_files])
 
 
 RESOURCE_NAMES_TO_GENERATE = ['shelf_book_name', 'shelf_name',
-                              'archived_book_name', 'deleted_book']
+                              'archived_book_name', 'deleted_book',
+                              'folder_name', 'location_name']
 ONEOFS_TO_GENERATE = ['book_oneof']
 
 PROTOC_OUTPUT_DIR = os.path.join('com', 'google', 'example', 'library', 'v1')

--- a/test/testdata/common_resources.proto
+++ b/test/testdata/common_resources.proto
@@ -1,0 +1,68 @@
+// Copyright 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains stub messages for common resources in GCP.
+// It is not intended to be directly generated, and is instead used by
+// other tooling to be able to match common resource patterns.
+syntax = "proto3";
+
+package google.cloud;
+
+import "google/api/resource.proto";
+
+
+message Project {
+  option (google.api.resource) = {
+    type: "cloudresourcemanager.googleapis.com/Project"
+    pattern: "projects/{project}"
+  };
+
+  string name = 1;
+}
+
+message Organization {
+  option (google.api.resource) = {
+    type: "cloudresourcemanager.googleapis.com/Organization"
+    pattern: "organizations/{organization}"
+  };
+
+  string name = 1;
+}
+
+message Folder {
+  option (google.api.resource) = {
+    type: "cloudresourcemanager.googleapis.com/Folder"
+    pattern: "folders/{folder}"
+  };
+
+  string name = 1;
+}
+
+message BillingAccount {
+  option (google.api.resource) = {
+    type: "cloudbilling.googleapis.com/BillingAccount"
+    pattern: "billingAccounts/{billing_account}"
+  };
+
+  string name = 1;
+}
+
+message Location {
+  option (google.api.resource) = {
+    type: "locations.googleapis.com/Location"
+    pattern: "projects/{project}/locations/{location}"
+  };
+
+  string name = 1;
+}

--- a/test/testdata/java_folder_name.baseline
+++ b/test/testdata/java_folder_name.baseline
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.example.library.v1;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.api.resourcenames.ResourceName;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+@javax.annotation.Generated("by GAPIC protoc plugin")
+public class FolderName implements ResourceName {
+
+  private static final PathTemplate PATH_TEMPLATE =
+      PathTemplate.createWithoutUrlEncoding("folders/{folder}");
+
+  private volatile Map<String, String> fieldValuesMap;
+
+  private final String folder;
+
+  public String getFolder() {
+    return folder;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  private FolderName(Builder builder) {
+    folder = Preconditions.checkNotNull(builder.getFolder());
+  }
+
+  public static FolderName of(String folder) {
+    return newBuilder()
+      .setFolder(folder)
+      .build();
+  }
+
+  public static String format(String folder) {
+    return newBuilder()
+      .setFolder(folder)
+      .build()
+      .toString();
+  }
+
+  public static FolderName parse(String formattedString) {
+    if (formattedString.isEmpty()) {
+      return null;
+    }
+    Map<String, String> matchMap =
+        PATH_TEMPLATE.validatedMatch(formattedString, "FolderName.parse: formattedString not in valid format");
+    return of(matchMap.get("folder"));
+  }
+
+  public static List<FolderName> parseList(List<String> formattedStrings) {
+    List<FolderName> list = new ArrayList<>(formattedStrings.size());
+    for (String formattedString : formattedStrings) {
+      list.add(parse(formattedString));
+    }
+    return list;
+  }
+
+  public static List<String> toStringList(List<FolderName> values) {
+    List<String> list = new ArrayList<String>(values.size());
+    for (FolderName value : values) {
+      if (value == null) {
+        list.add("");
+      } else {
+        list.add(value.toString());
+      }
+    }
+    return list;
+  }
+
+  public static boolean isParsableFrom(String formattedString) {
+    return PATH_TEMPLATE.matches(formattedString);
+  }
+
+  public Map<String, String> getFieldValuesMap() {
+    if (fieldValuesMap == null) {
+      synchronized (this) {
+        if (fieldValuesMap == null) {
+          ImmutableMap.Builder<String, String> fieldMapBuilder = ImmutableMap.builder();
+          fieldMapBuilder.put("folder", folder);
+          fieldValuesMap = fieldMapBuilder.build();
+        }
+      }
+    }
+    return fieldValuesMap;
+  }
+
+  public String getFieldValue(String fieldName) {
+    return getFieldValuesMap().get(fieldName);
+  }
+
+  @Override
+  public String toString() {
+    return PATH_TEMPLATE.instantiate("folder", folder);
+  }
+
+  /** Builder for FolderName. */
+  public static class Builder {
+
+    private String folder;
+
+    public String getFolder() {
+      return folder;
+    }
+
+    public Builder setFolder(String folder) {
+      this.folder = folder;
+      return this;
+    }
+
+    private Builder() {
+    }
+
+    private Builder(FolderName folderName) {
+      folder = folderName.folder;
+    }
+
+    public FolderName build() {
+      return new FolderName(this);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof FolderName) {
+      FolderName that = (FolderName) o;
+      return (this.folder.equals(that.folder));
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= folder.hashCode();
+    return h;
+  }
+}
+

--- a/test/testdata/java_location_name.baseline
+++ b/test/testdata/java_location_name.baseline
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.example.library.v1;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.api.resourcenames.ResourceName;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+@javax.annotation.Generated("by GAPIC protoc plugin")
+public class LocationName implements ResourceName {
+
+  private static final PathTemplate PATH_TEMPLATE =
+      PathTemplate.createWithoutUrlEncoding("projects/{project}/locations/{location}");
+
+  private volatile Map<String, String> fieldValuesMap;
+
+  private final String project;
+  private final String location;
+
+  public String getProject() {
+    return project;
+  }
+
+  public String getLocation() {
+    return location;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  private LocationName(Builder builder) {
+    project = Preconditions.checkNotNull(builder.getProject());
+    location = Preconditions.checkNotNull(builder.getLocation());
+  }
+
+  public static LocationName of(String project, String location) {
+    return newBuilder()
+      .setProject(project)
+      .setLocation(location)
+      .build();
+  }
+
+  public static String format(String project, String location) {
+    return newBuilder()
+      .setProject(project)
+      .setLocation(location)
+      .build()
+      .toString();
+  }
+
+  public static LocationName parse(String formattedString) {
+    if (formattedString.isEmpty()) {
+      return null;
+    }
+    Map<String, String> matchMap =
+        PATH_TEMPLATE.validatedMatch(formattedString, "LocationName.parse: formattedString not in valid format");
+    return of(matchMap.get("project"), matchMap.get("location"));
+  }
+
+  public static List<LocationName> parseList(List<String> formattedStrings) {
+    List<LocationName> list = new ArrayList<>(formattedStrings.size());
+    for (String formattedString : formattedStrings) {
+      list.add(parse(formattedString));
+    }
+    return list;
+  }
+
+  public static List<String> toStringList(List<LocationName> values) {
+    List<String> list = new ArrayList<String>(values.size());
+    for (LocationName value : values) {
+      if (value == null) {
+        list.add("");
+      } else {
+        list.add(value.toString());
+      }
+    }
+    return list;
+  }
+
+  public static boolean isParsableFrom(String formattedString) {
+    return PATH_TEMPLATE.matches(formattedString);
+  }
+
+  public Map<String, String> getFieldValuesMap() {
+    if (fieldValuesMap == null) {
+      synchronized (this) {
+        if (fieldValuesMap == null) {
+          ImmutableMap.Builder<String, String> fieldMapBuilder = ImmutableMap.builder();
+          fieldMapBuilder.put("project", project);
+          fieldMapBuilder.put("location", location);
+          fieldValuesMap = fieldMapBuilder.build();
+        }
+      }
+    }
+    return fieldValuesMap;
+  }
+
+  public String getFieldValue(String fieldName) {
+    return getFieldValuesMap().get(fieldName);
+  }
+
+  @Override
+  public String toString() {
+    return PATH_TEMPLATE.instantiate("project", project, "location", location);
+  }
+
+  /** Builder for LocationName. */
+  public static class Builder {
+
+    private String project;
+    private String location;
+
+    public String getProject() {
+      return project;
+    }
+
+    public String getLocation() {
+      return location;
+    }
+
+    public Builder setProject(String project) {
+      this.project = project;
+      return this;
+    }
+
+    public Builder setLocation(String location) {
+      this.location = location;
+      return this;
+    }
+
+    private Builder() {
+    }
+
+    private Builder(LocationName locationName) {
+      project = locationName.project;
+      location = locationName.location;
+    }
+
+    public LocationName build() {
+      return new LocationName(this);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof LocationName) {
+      LocationName that = (LocationName) o;
+      return (this.project.equals(that.project))
+          && (this.location.equals(that.location));
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= project.hashCode();
+    h *= 1000003;
+    h ^= location.hashCode();
+    return h;
+  }
+}
+

--- a/test/testdata/library_gapic.yaml
+++ b/test/testdata/library_gapic.yaml
@@ -31,27 +31,10 @@ collections:
       entity_name: archived_book
 - name_pattern: _deleted-book_
   entity_name: deleted_book
+- name_pattern: folders/{folder}
+  entity_name: folder
+- name_pattern: projects/{project}/locations/{location}
+  entity_name: location
 interfaces:
 - name: google.example.library.v1.LibraryService
-  #retry_codes_def: <snip>
-  #retry_params_def: <snip>
-  #smoke_test: <snip>
-  #experimental_features: <snip>
-  #methods: <snip>
-resource_name_generation:
-- message_name: Book
-  field_entity_map:
-    name: book
-- message_name: BookFromArchive
-  field_entity_map:
-    name: archived_book
-- message_name: BookFromAnywhere
-  field_entity_map:
-    name: book_oneof
-- message_name: Shelf
-  field_entity_map:
-    name: shelf
-    theme: "*"
-- message_name: ListBooksResponse
-  field_entity_map:
-    books: book
+

--- a/test/testdata/library_gapic_v2.yaml
+++ b/test/testdata/library_gapic_v2.yaml
@@ -1,14 +1,11 @@
 type: com.google.api.codegen.ConfigProto
 config_schema_version: 2.0.0
 collections:
-  - name_pattern: projects/{project}/shelves/{shelf}/books/{book}
+  - entity_name: book
     language_overrides:
       - language: java
         entity_name: shelf_book
-  - name_pattern: _deleted-book_
-    entity_name: deleted_book
-  - name_pattern: archives/{archive}/books/{book}
-    entity_name: archive_book
+  - entity_name: archive_book
     language_overrides:
     - language: java
       entity_name: archived_book

--- a/test/testdata/library_simple.proto
+++ b/test/testdata/library_simple.proto
@@ -92,6 +92,9 @@ message GetShelfRequest {
     (google.api.resource_reference).type = "library.googleapis.com/Shelf"
   ];
 
+  string parent = 2 [
+    (google.api.resource_reference).child_type = "locations.googleapis.com/Location"];
+
   // To test 'options' parameter name conflict.
   string options = 4;
 }
@@ -112,6 +115,12 @@ message GetBookRequest {
   string name = 1 [
     (google.api.resource_reference).type = "library.googleapis.com/Book"
   ];
+
+  string place = 2 [
+    (google.api.resource_reference).type = "locations.googleapis.com/Location"];
+
+  string folder = 3 [
+    (google.api.resource_reference).type = "cloudresourcemanager.googleapis.com/Folder"];
 }
 
 // Request message for LibraryService.ListBooks.


### PR DESCRIPTION
This is the plugin portion of the wider scope fix. See https://github.com/googleapis/gapic-generator/pull/2979 for more details.
Mostly fixes common resource names issue and wrong gapic_v2 spec assumption.

This does not fix all of the problems. One of the remaining issues is to perform deep merge instead of shalow merge of resource names annotations and gapic_v2 collections. Currently the plugin performs the shallow merge, meaning if there is a resource name in both places (annotations and gapic_v2) it will overwirte resource gapic_v2 data with annotations data completely (while it should keep the language_overrides from gapic_v1 portion).