### PR TITLE
Support deprecated resource names

### DIFF
--- a/plugin/cli/gapic_plugin.py
+++ b/plugin/cli/gapic_plugin.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 
 # Copyright 2016, Google Inc.
 # All rights reserved.

--- a/plugin/cli/gapic_plugin.py
+++ b/plugin/cli/gapic_plugin.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 
 # Copyright 2016, Google Inc.
 # All rights reserved.

--- a/plugin/templates/parent_resource_name.mustache
+++ b/plugin/templates/parent_resource_name.mustache
@@ -16,7 +16,9 @@ package {{package}};
 
 import {{resource_name_global_package_name}}.ResourceName;
 
-// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ */
 @javax.annotation.Generated("by GAPIC protoc plugin")
 public abstract class {{class_name}} implements ResourceName {
   protected {{class_name}}() {}

--- a/plugin/templates/resource_name.mustache
+++ b/plugin/templates/resource_name.mustache
@@ -24,7 +24,9 @@ import java.util.List;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 @javax.annotation.Generated("by GAPIC protoc plugin")
-{{deprecation_message}}
+{{#deprecated}}
+@Deprecated This resource name class will be removed in the next major version.
+{{/deprecated}}
 public class {{class_name}} {{extension_keyword}} {{parent_interface}} {
 
   private static final PathTemplate PATH_TEMPLATE =

--- a/plugin/templates/resource_name.mustache
+++ b/plugin/templates/resource_name.mustache
@@ -22,10 +22,16 @@ import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
 
-// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ {{#deprecated}}
+ *
+ * @deprecated This resource name class will be removed in the next major version.
+ {{/deprecated}}
+ */
 @javax.annotation.Generated("by GAPIC protoc plugin")
 {{#deprecated}}
-@Deprecated This resource name class will be removed in the next major version.
+@Deprecated
 {{/deprecated}}
 public class {{class_name}} {{extension_keyword}} {{parent_interface}} {
 

--- a/plugin/templates/resource_name.mustache
+++ b/plugin/templates/resource_name.mustache
@@ -24,6 +24,7 @@ import java.util.List;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 @javax.annotation.Generated("by GAPIC protoc plugin")
+{{deprecation_message}}
 public class {{class_name}} {{extension_keyword}} {{parent_interface}} {
 
   private static final PathTemplate PATH_TEMPLATE =

--- a/plugin/templates/resource_name.py
+++ b/plugin/templates/resource_name.py
@@ -59,7 +59,7 @@ class ResourceNameBase(object):
 
 class ResourceName(ResourceNameBase):
 
-    def __init__(self, collection_config, java_package, oneof, is_deprecated):
+    def __init__(self, collection_config, java_package, oneof):
         super(ResourceName, self).__init__(
             casing_utils.get_resource_type_class_name(
                 collection_config.java_entity_name), java_package)
@@ -80,14 +80,11 @@ class ResourceName(ResourceNameBase):
                 casing_utils.get_parent_resource_name_class_name(
                     oneof.oneof_name)
             self.extension_keyword = 'extends'
+            self.deprecated = True
         else:
             self.parent_interface = 'ResourceName'
             self.extension_keyword = 'implements'
-        if is_deprecated:
-            self.deprecation_message = \
-                '@Deprecated this resource name class will be removed in the next major version.'
-        else:
-            self.deprecation_message = ''
+            self.deprecated = False
         self.parameter_list = [{
             'parameter': symbol_table.getNewSymbol(
                 casing_utils.lower_underscore_to_lower_camel(lit)),
@@ -140,13 +137,13 @@ class ResourceNameFactory(ResourceNameBase):
             'resource_type_var_name': resource.var_name,
             'resource_package': resource.package,
         } for resource in (ResourceName(x, java_package, oneof)
-                           for x in oneof.resource_list)]
+                           for x in oneof.legacy_resource_list)]
         self.fixed_resource_types = [{
             'resource_type_class_name': resource.class_name,
             'resource_type_var_name': resource.var_name,
             'resource_package': resource.package,
         } for resource in (ResourceNameFixed(x, java_package, oneof)
-                           for x in oneof.fixed_resource_list)]
+                           for x in oneof.legacy_fixed_resource_list)]
         self.resource_types = (self.single_resource_types
                                + self.fixed_resource_types)
 
@@ -183,9 +180,11 @@ class ResourceNameFixed(ResourceNameBase):
                 casing_utils.get_parent_resource_name_class_name(
                     oneof.oneof_name)
             self.extension_keyword = 'extends'
+            self.deprecated = True
         else:
             self.parent_interface = 'ResourceName'
             self.extension_keyword = 'implements'
+            self.deprecated = False
 
     def template_name(self):
         return "resource_name_fixed.mustache"

--- a/plugin/templates/resource_name.py
+++ b/plugin/templates/resource_name.py
@@ -59,7 +59,7 @@ class ResourceNameBase(object):
 
 class ResourceName(ResourceNameBase):
 
-    def __init__(self, collection_config, java_package, oneof):
+    def __init__(self, collection_config, java_package, oneof, is_deprecated):
         super(ResourceName, self).__init__(
             casing_utils.get_resource_type_class_name(
                 collection_config.java_entity_name), java_package)
@@ -83,6 +83,11 @@ class ResourceName(ResourceNameBase):
         else:
             self.parent_interface = 'ResourceName'
             self.extension_keyword = 'implements'
+        if is_deprecated:
+            self.deprecation_message = \
+                '@Deprecated this resource name class will be removed in the next major version.'
+        else:
+            self.deprecation_message = ''
         self.parameter_list = [{
             'parameter': symbol_table.getNewSymbol(
                 casing_utils.lower_underscore_to_lower_camel(lit)),

--- a/plugin/templates/resource_name_factory.mustache
+++ b/plugin/templates/resource_name_factory.mustache
@@ -16,9 +16,13 @@ package {{package}};
 
 import {{resource_name_global_package_name}}.ResourceName;
 
-// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ *
+ * @deprecated This resource name class will be removed in the next major version.
+ */
 @javax.annotation.Generated("by GAPIC protoc plugin")
-@Deprecated This resource name class will be removed in the next major version.
+@Deprecated
 public class {{class_name}} {
   private {{class_name}}() {}
 

--- a/plugin/templates/resource_name_factory.mustache
+++ b/plugin/templates/resource_name_factory.mustache
@@ -18,6 +18,7 @@ import {{resource_name_global_package_name}}.ResourceName;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 @javax.annotation.Generated("by GAPIC protoc plugin")
+@Deprecated This resource name class will be removed in the next major version.
 public class {{class_name}} {
   private {{class_name}}() {}
 

--- a/plugin/templates/resource_name_fixed.mustache
+++ b/plugin/templates/resource_name_fixed.mustache
@@ -18,10 +18,16 @@ import {{resource_name_global_package_name}}.ResourceName;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 
-// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ {{#deprecated}}
+ *
+ * @deprecated This resource name class will be removed in the next major version.
+ {{/deprecated}}
+ */
 @javax.annotation.Generated("by GAPIC protoc plugin")
 {{#deprecated}}
-@Deprecated This resource name class will be removed in the next major version.
+@Deprecated
 {{/deprecated}}
 public class {{class_name}} {{extension_keyword}} {{parent_interface}} {
 

--- a/plugin/templates/resource_name_fixed.mustache
+++ b/plugin/templates/resource_name_fixed.mustache
@@ -20,6 +20,9 @@ import java.util.Map;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 @javax.annotation.Generated("by GAPIC protoc plugin")
+{{#deprecated}}
+@Deprecated This resource name class will be removed in the next major version.
+{{/deprecated}}
 public class {{class_name}} {{extension_keyword}} {{parent_interface}} {
 
   private static final String FIXED_VALUE = "{{fixed_value}}";

--- a/plugin/templates/untyped_resource_name.mustache
+++ b/plugin/templates/untyped_resource_name.mustache
@@ -23,6 +23,7 @@ import java.util.Map;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 @javax.annotation.Generated("by GAPIC protoc plugin")
+@Deprecated This resource name class will be removed in the next major version.
 public class {{class_name}} {{extension_keyword}} {{parent_interface}} {
 
   private final String rawValue;

--- a/plugin/templates/untyped_resource_name.mustache
+++ b/plugin/templates/untyped_resource_name.mustache
@@ -21,9 +21,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ *
+ * @deprecated This resource name class will be removed in the next major version.
+ */
 @javax.annotation.Generated("by GAPIC protoc plugin")
-@Deprecated This resource name class will be removed in the next major version.
+@Deprecated
 public class {{class_name}} {{extension_keyword}} {{parent_interface}} {
 
   private final String rawValue;

--- a/plugin/utils/gapic_utils.py
+++ b/plugin/utils/gapic_utils.py
@@ -326,6 +326,7 @@ def _get_resource_for_deprecate_pattern(
         deprecated_collection_pattern,
         pattern_resource_map):
     resources = pattern_resource_map[deprecated_collection_pattern]
+    resources = [r for r in resources if len(r.pattern) > 1]
 
     # A deprecated collection pattern belonging to multiple resources
     # is very unlikely and cannot be nicely handled by resource
@@ -336,6 +337,9 @@ def _get_resource_for_deprecate_pattern(
         raise ValueError('Not supported: pattern of a deprecated '
                          'collections belongs to multiple resources: '
                          '{}'.format(deprecated_collection_pattern))
+    if not resources:
+        raise ValueError('Not supported: deprecating a single-pattern'
+                         'resource name.')
     resource = resources[0]
     if len(resource.pattern) <= 1:
         raise ValueError('deprecated collection point to a '
@@ -363,15 +367,12 @@ def update_collections_with_deprecated_resources(
             entity_name = deprecated_collection['entity_name']
             name_pattern = deprecated_collection['name_pattern']
 
-            if entity_name in collections:
-                raise ValueError(
-                    'deprecating a single-pattern '
-                    'resource is not allowed: {}'.format(entity_name))
+            if entity_name not in collections:
+                collections[entity_name] = deprecated_collection
             if name_pattern not in pattern_resource_map:
                 raise ValueError(
                     'deprecated collection has '
                     'an unknown name pattern: {}'.format(name_pattern))
-            collections[entity_name] = deprecated_collection
             resource = _get_resource_for_deprecate_pattern(
                 name_pattern, pattern_resource_map)
             oneof_name = to_snake(resource.type.split('/')[-1]) + '_oneof'

--- a/plugin/utils/gapic_utils.py
+++ b/plugin/utils/gapic_utils.py
@@ -171,7 +171,7 @@ def reconstruct_gapic_yaml(gapic_v2, request):  # noqa: C901
     # all multi-pattern resources defined in protos to collection_oneofs.
     #
     # Note we no longer need to derive entity names from patterns with the
-    # new design of multi-pattern resourc names. However, we load them from
+    # new design of multi-pattern resourcs names. However, we load them from
     # deprecated_collections in gapic v2 to continue to generate existing
     # resource name classes for backward-compatibility.
     for typ, res in type_resource_map.items():
@@ -269,7 +269,7 @@ def get_all_resource_references(request):
 def get_parent_resource(res, pattern_map):
     """ Return the parent resource of res.
     We consider resource Foo to be resource Bar's parent iff Foo and Bar have
-    the same number of patterns, and for each pattern 'B'' in Bar, there is
+    the same number of patterns, and for each pattern 'B' in Bar, there is
     a pattern 'F' in Foo , such that 'F' is the parent 'B'.
     Returns None if we can't find the parent of res.
     """

--- a/plugin/utils/gapic_utils.py
+++ b/plugin/utils/gapic_utils.py
@@ -56,8 +56,8 @@ def create_gapic_config(gapic_yaml):
         find_single_and_fixed_entities(all_entities)
 
     collections = load_collection_configs(single_resource_names, collections)
-    fixed_collections = {}
 
+    fixed_collections = {}
     # TODO(andrealin): Remove the fixed_resource_name_values
     # parsing once they no longer exist in GAPIC configs.
     if 'fixed_resource_name_values' in gapic_yaml:
@@ -383,7 +383,6 @@ def build_parent_patterns(patterns):
             last_index -= 1
         last_index += 1
         return '/'.join(segs[:last_index])
-
     return [_parent_pattern(p) for p in patterns if not (isFixedPattern(p))]
 
 
@@ -472,17 +471,18 @@ def load_collection_oneofs(config_list, existing_collections,
         for collection in collection_names:
             if (collection not in existing_collections and
                     collection not in fixed_collections):
-                raise ValueError('Collection specified in collection '
-                                 'oneof, but no matching collection '
-                                 'was found. Oneof: ' + root_type_name +
-                                 ', Collection: ' + collection)
+                raise ValueError(
+                    'Collection specified in collection '
+                    'oneof, but no matching collection '
+                    'was found. Oneof: ' + root_type_name +
+                    ', Collection: ' + collection)
             if collection in existing_collections:
                 resources.append(existing_collections[collection])
             else:
                 fixed_resources.append(fixed_collections[collection])
 
         if (root_type_name in existing_oneofs or
-                root_type_name in existing_collections or
+            root_type_name in existing_collections or
                 root_type_name in fixed_collections):
             raise ValueError('Found two collection oneofs with same name: ' +
                              root_type_name)
@@ -568,9 +568,7 @@ class GapicConfig(object):
                  collection_configs={},
                  fixed_collections={},
                  collection_oneofs={},
-                 deprecated_collections={},
                  **kwargs):
         self.collection_configs = collection_configs
         self.fixed_collections = fixed_collections
         self.collection_oneofs = collection_oneofs
-        self.deprecated_collections = deprecated_collections

--- a/plugin/utils/gapic_utils.py
+++ b/plugin/utils/gapic_utils.py
@@ -220,7 +220,7 @@ def get_all_resources(request):  # noqa: C901
         type_resource_map[res.type] = res
         # It is very likely that we will have multiple resources that
         # supports a same pattern in the future (for example, Firestore),
-        # so let's put the resources in a list preemptively. 
+        # so let's put the resources in a list preemptively.
         for ptn in res.pattern:
             pattern_resource_map.setdefault(ptn, [])
             pattern_resource_map[ptn].append(res)
@@ -281,7 +281,7 @@ def get_parent_resource(res, pattern_map):
         if not parent_candidates:
             parent_candidates = pattern_map[parent_pattern]
         else:
-            parent_candidates = [r for r in parent_candidates 
+            parent_candidates = [r for r in parent_candidates
                                  if r in pattern_map[parent_pattern]]
 
     if not parent_candidates:
@@ -359,7 +359,7 @@ def update_collections_with_deprecated_resources(  # noqa: C901
             if len(resources) > 1:
                 raise ValueError('Not supported: pattern of a deprecated '
                                  'collections belongs to multiple resources: '
-                                     '{}'.format(name_pattern))
+                                 '{}'.format(name_pattern))
             res = resources[0]
             if len(res.pattern) <= 1:
                 raise ValueError('deprecated collection point to a '

--- a/plugin/utils/gapic_utils.py
+++ b/plugin/utils/gapic_utils.py
@@ -383,7 +383,7 @@ def build_parent_patterns(patterns):
             last_index -= 1
         last_index += 1
         return '/'.join(segs[:last_index])
-    return [_parent_pattern(p) for p in patterns if not (isFixedPattern(p))]
+    return [_parent_pattern(p) for p in patterns if not(isFixedPattern(p))]
 
 
 def _is_variable_segment(segment):
@@ -404,7 +404,7 @@ def find_single_and_fixed_entities(all_resource_names):
 
 
 def isFixedPattern(pattern):
-    return not ('{' in pattern or '*' in pattern)
+    return not('{' in pattern or '*' in pattern)
 
 
 def load_collection_configs(config_list, existing_configs):
@@ -421,6 +421,7 @@ def load_collection_configs(config_list, existing_configs):
             if 'common_resource_name' in override:
                 continue
             java_entity_name = override['entity_name']
+
         if entity_name in existing_configs:
             existing_name_pattern = existing_configs[entity_name].name_pattern
             if existing_name_pattern != name_pattern:
@@ -474,8 +475,8 @@ def load_collection_oneofs(config_list, existing_collections,
                 raise ValueError(
                     'Collection specified in collection '
                     'oneof, but no matching collection '
-                    'was found. Oneof: ' + root_type_name +
-                    ', Collection: ' + collection)
+                    'was found. Oneof: ' +
+                    root_type_name + ', Collection: ' + collection)
             if collection in existing_collections:
                 resources.append(existing_collections[collection])
             else:

--- a/plugin/utils/gapic_utils.py
+++ b/plugin/utils/gapic_utils.py
@@ -57,16 +57,21 @@ def create_gapic_config(gapic_yaml):
 
     collections = load_collection_configs(single_resource_names, collections)
     fixed_collections = {}
+
     # TODO(andrealin): Remove the fixed_resource_name_values
     # parsing once they no longer exist in GAPIC configs.
     if 'fixed_resource_name_values' in gapic_yaml:
         fixed_collections = load_fixed_configs(
-            gapic_yaml['fixed_resource_name_values'], fixed_collections,
-            collections, "fixed_value")
+            gapic_yaml['fixed_resource_name_values'],
+            fixed_collections,
+            collections,
+            "fixed_value")
     # Add the fixed resource names that are defined in the collections.
-    fixed_collections = load_fixed_configs(fixed_resource_names,
-                                           fixed_collections, collections,
-                                           "name_pattern")
+    fixed_collections = load_fixed_configs(
+        fixed_resource_names,
+        fixed_collections,
+        collections,
+        "name_pattern")
 
     oneofs = {}
     if 'collection_oneofs' in gapic_yaml:
@@ -108,8 +113,8 @@ def read_from_gapic_yaml(request):
     # away from it here is because this tool is supposed to have a short
     # shelf life, and it is safer to be backwards-looking than
     # forward-looking in this case.
-    if not gapic_yaml or gapic_yaml.get('config_schema_version',
-                                        '1.0.0') != '1.0.0':
+    if not gapic_yaml or gapic_yaml.get(
+            'config_schema_version', '1.0.0') != '1.0.0':
         gapic_yaml = reconstruct_gapic_yaml(gapic_yaml, request)
 
     return create_gapic_config(gapic_yaml)
@@ -179,10 +184,11 @@ def reconstruct_gapic_yaml(gapic_v2, request):  # noqa: C901
                 update_collections(parent_res, collections, collection_oneofs)
 
     # Load deprecated_collections.
-    update_collections_with_deprecated_resources(gapic_v2,
-                                                 pattern_resource_map,
-                                                 collections,
-                                                 collection_oneofs)
+    update_collections_with_deprecated_resources(
+        gapic_v2,
+        pattern_resource_map,
+        collections,
+        collection_oneofs)
 
     # Take the collections and collection_oneofs, convert them back to lists,
     # and drop them on the GAPIC YAML.
@@ -464,8 +470,8 @@ def load_collection_oneofs(config_list, existing_collections,
         resources = []
         fixed_resources = []
         for collection in collection_names:
-            if (collection not in existing_collections
-                    and collection not in fixed_collections):
+            if (collection not in existing_collections and
+                    collection not in fixed_collections):
                 raise ValueError('Collection specified in collection '
                                  'oneof, but no matching collection '
                                  'was found. Oneof: ' + root_type_name +
@@ -475,9 +481,9 @@ def load_collection_oneofs(config_list, existing_collections,
             else:
                 fixed_resources.append(fixed_collections[collection])
 
-        if (root_type_name in existing_oneofs
-                or root_type_name in existing_collections
-                or root_type_name in fixed_collections):
+        if (root_type_name in existing_oneofs or
+                root_type_name in existing_collections or
+                root_type_name in fixed_collections):
             raise ValueError('Found two collection oneofs with same name: ' +
                              root_type_name)
         existing_oneofs[root_type_name] = CollectionOneof(
@@ -490,14 +496,14 @@ def collect_resource_name_types(gapic_config, java_package):
 
     for collection_config in gapic_config.collection_configs.values():
         oneof = get_oneof_for_resource(collection_config, gapic_config)
-        resource = resource_name.ResourceName(collection_config, java_package,
-                                              oneof)
+        resource = resource_name.ResourceName(
+            collection_config, java_package, oneof)
         resources.append(resource)
 
     for fixed_config in gapic_config.fixed_collections.values():
         oneof = get_oneof_for_resource(fixed_config, gapic_config)
-        resource = resource_name.ResourceNameFixed(fixed_config, java_package,
-                                                   oneof)
+        resource = resource_name.ResourceNameFixed(
+            fixed_config, java_package, oneof)
         resources.append(resource)
 
     for oneof_config in gapic_config.collection_oneofs.values():

--- a/plugin/utils/gapic_utils.py
+++ b/plugin/utils/gapic_utils.py
@@ -421,10 +421,7 @@ def load_collection_configs(config_list, existing_configs):
             override = overrides[0]
             if 'common_resource_name' in override:
                 continue
-            if 'entity_name' in override:
-                java_entity_name = override['entity_name']
-        if not java_entity_name:
-            continue
+            java_entity_name = override['entity_name']
         if entity_name in existing_configs:
             existing_name_pattern = existing_configs[entity_name].name_pattern
             if existing_name_pattern != name_pattern:
@@ -432,12 +429,15 @@ def load_collection_configs(config_list, existing_configs):
                     'Found collection configs with same entity name '
                     'but different patterns. Name: ' + entity_name)
         else:
-            existing_configs[entity_name] = CollectionConfig(
-                entity_name, name_pattern, java_entity_name)
+            existing_configs[entity_name] = CollectionConfig(entity_name,
+                                                             name_pattern,
+                                                             java_entity_name)
     return existing_configs
 
 
-def load_fixed_configs(config_list, existing_configs, existing_collections,
+def load_fixed_configs(config_list,
+                       existing_configs,
+                       existing_collections,
                        pattern_key_name):
     for config in config_list:
         entity_name = config['entity_name']
@@ -537,6 +537,7 @@ def create_field_name(message_name, field):
 
 
 class CollectionConfig(object):
+
     def __init__(self, entity_name, name_pattern, java_entity_name):
         self.entity_name = entity_name
         self.name_pattern = name_pattern
@@ -544,6 +545,7 @@ class CollectionConfig(object):
 
 
 class FixedCollectionConfig(object):
+
     def __init__(self, entity_name, fixed_value, java_entity_name):
         self.entity_name = entity_name
         self.fixed_value = fixed_value
@@ -551,6 +553,7 @@ class FixedCollectionConfig(object):
 
 
 class CollectionOneof(object):
+
     def __init__(self, oneof_name, legacy_resources, legacy_fixed_resources,
                  legacy_collection_names):
         self.oneof_name = oneof_name
@@ -560,15 +563,14 @@ class CollectionOneof(object):
 
 
 class GapicConfig(object):
+
     def __init__(self,
                  collection_configs={},
                  fixed_collections={},
                  collection_oneofs={},
                  deprecated_collections={},
-                 gapic_version=1,
                  **kwargs):
         self.collection_configs = collection_configs
         self.fixed_collections = fixed_collections
         self.collection_oneofs = collection_oneofs
         self.deprecated_collections = deprecated_collections
-        self.gapic_version = gapic_version

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-chevron >= 0.13.1
+chevron>=0.13.1
 protobuf>=3.7.1
 pyyaml>=3.12
-ply == 3.8
+ply>=3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 chevron >= 0.13.1
 protobuf>=3.7.1
 pyyaml>=3.12
-ply >= 3.8
+ply == 3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 chevron >= 0.13.1
 protobuf>=3.7.1
 pyyaml>=3.12
-ply == 3.8
+ply >= 3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-chevron>=0.13.1
+chevron >= 0.13.1
 protobuf>=3.7.1
 pyyaml>=3.12
-ply==3.8
+ply == 3.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 chevron>=0.13.1
 protobuf>=3.7.1
 pyyaml>=3.12
-ply>=3.8
+ply==3.8

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ version = '0.0.18'
 install_requires = [
     'chevron >= 0.13.1',
     'protobuf >= 3.7.1',
-    # 'google-gax >= 0.12.3',
     'pyyaml >= 3.12',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ version = '0.0.18'
 install_requires = [
     'chevron >= 0.13.1',
     'protobuf >= 3.7.1',
-    'google-gax >= 0.12.3',
+    # 'google-gax >= 0.12.3',
     'pyyaml >= 3.12',
 ]
 

--- a/test/test_gapic_utils.py
+++ b/test/test_gapic_utils.py
@@ -56,6 +56,7 @@ def test_update_collections_multi_pattern():
         }
     }
 
+
 def test_update_collections_single_pattern():
     res = resource_pb2.ResourceDescriptor()
     res.type = 'test/Book'
@@ -71,6 +72,7 @@ def test_update_collections_single_pattern():
         }
     }
     assert collection_oneofs == {}
+
 
 def test_library_gapic_v1():
 

--- a/test/test_gapic_utils.py
+++ b/test/test_gapic_utils.py
@@ -84,8 +84,8 @@ def test_get_parent_resources_single_pattern():
     shelf.pattern.append("shelves/{shelf}")
 
     pattern_map = {
-        "shelves/{shelf}/books/{book}": book,
-        "shelves/{shelf}": shelf
+        "shelves/{shelf}/books/{book}": [book],
+        "shelves/{shelf}": [shelf]
     }
     assert shelf == gapic_utils.get_parent_resource(book, pattern_map)
 
@@ -96,16 +96,20 @@ def test_get_parent_resources_multi_pattern():
     book.pattern.append("shelves/{shelf}/books/{book}")
     book.pattern.append("projects/{project}/books/{book}")
 
+    shelf = resource_pb2.ResourceDescriptor()
+    shelf.type = 'test/Shelf'
+    shelf.pattern.append("shelves/{shelf}/books/{book}")
+
     parent = resource_pb2.ResourceDescriptor()
     parent.type = 'test/Parent'
     parent.pattern.append("shelves/{shelf}")
     parent.pattern.append("projects/{project}")
 
     pattern_map = {
-        "shelves/{shelf}/books/{book}": book,
-        "projects/{project}/books/{book}": book,
-        "shelves/{shelf}": parent,
-        "projects/{project}": parent
+        "shelves/{shelf}/books/{book}": [book],
+        "projects/{project}/books/{book}": [book],
+        "shelves/{shelf}": [parent],
+        "projects/{project}": [parent]
     }
     assert parent == gapic_utils.get_parent_resource(book, pattern_map)
 
@@ -127,9 +131,9 @@ def test_get_parent_resources_multi_pattern_fail():
     book_parent.pattern.append("projects/{project}/locations/{location}")
 
     pattern_map = {
-        "shelves/{shelf}/books/{book}": book,
-        "projects/{project}/books/{book}": book,
-        "shelves/{shelf}": parent,
+        "shelves/{shelf}/books/{book}": [book],
+        "projects/{project}/books/{book}": [book],
+        "shelves/{shelf}": [parent],
     }
     assert gapic_utils.get_parent_resource(book, pattern_map) is None
 
@@ -166,8 +170,8 @@ def test_update_collections_with_deprecated_collections():
     }
     collections = {}
     pattern_map = {
-        "archives/{archive}/books/{book}": book,
-        "shelves/{shelf}/books/{book}": book
+        "archives/{archive}/books/{book}": [book],
+        "shelves/{shelf}/books/{book}": [book]
     }
 
     gapic_utils.update_collections_with_deprecated_resources(

--- a/test/test_gapic_utils.py
+++ b/test/test_gapic_utils.py
@@ -39,91 +39,38 @@ def test_build_parent_patterns():
     assert gapic_utils.build_parent_patterns(patterns) == expected_parents
 
 
-def test_reversed_variable_segments():
-    assert gapic_utils.reversed_variable_segments(
-        "foos/{foo}/bars/{bar}") == ["bar", "foo"]
-    assert gapic_utils.reversed_variable_segments(
-        "foos/{foo}/busy/bars/{bar}") == ["bar", "foo"]
-    assert gapic_utils.reversed_variable_segments(
-        "_deleted-topic_") == ["topic", "deleted"]
-
-
-def test_build_trie_from_segments_list():
-    segments_list = [
-        ["bar", "foo"],
-        ["bar", "baz", "foo"]
-    ]
-    expected_trie = {
-        "bar": {
-            "foo": {},
-            "baz": {"foo": {}}
-        }
-    }
-    assert gapic_utils.build_trie_from_segments_list(
-        segments_list) == expected_trie
-
-
-def test_build_entity_names():
-    assert gapic_utils.build_entity_names([
-        "foos/{foo}/bars/{bar}"], "") == \
-        {"foos/{foo}/bars/{bar}": "bar"}
-    assert gapic_utils.build_entity_names([
-        "foos/{foo}/bars/{bar}"], "fuzz") == \
-        {"foos/{foo}/bars/{bar}": "fuzz"}
-    assert gapic_utils.build_entity_names([
-        "foos/{foo}/bars/{bar}",
-        "foos/{foo}/bazs/{baz}/bars/{bar}"], "") == \
-        {"foos/{foo}/bars/{bar}": "foo",
-         "foos/{foo}/bazs/{baz}/bars/{bar}": "baz"}
-    assert gapic_utils.build_entity_names([
-        "foos/{foo}/bars/{bar}",
-        "foos/{foo}/bazs/{baz}/bars/{bar}"], "bar") == \
-        {"foos/{foo}/bars/{bar}": "foo_bar",
-         "foos/{foo}/bazs/{baz}/bars/{bar}": "baz_bar"}
-    assert gapic_utils.build_entity_names([
-        "foos/{foo}/bars/{bar}",
-        "foos/{foo}/bazs/{baz}/bars/{bar}",
-        "foos/{foo}/wizzs/{wizz}/bazs/{baz}/bars/{bar}"
-    ], "bar") == \
-        {"foos/{foo}/bars/{bar}": "foo_bar",
-         "foos/{foo}/bazs/{baz}/bars/{bar}": "foo_baz_bar",
-            "foos/{foo}/wizzs/{wizz}/bazs/{baz}/bars/{bar}": "wizz_baz_bar"}
-    assert gapic_utils.build_entity_names([
-        "projects/{project}/topics/{topic}",
-        "_deleted-topic_",
-    ], "topic") == {
-        "projects/{project}/topics/{topic}": "project_topic",
-        "_deleted-topic_": "deleted_topic"
-    }
-
-
-def test_update_collections():
+def test_update_collections_multi_pattern():
     res = resource_pb2.ResourceDescriptor()
     res.type = 'test/Book'
     res.pattern.append("shelves/{shelf}/books/{book}")
     res.pattern.append("archives/{archive}/books/{book}")
-    res.history = resource_pb2.ResourceDescriptor.ORIGINALLY_SINGLE_PATTERN
 
     collections = {}
     collection_oneofs = {}
-    gapic_utils.update_collections(res, {}, collections, collection_oneofs)
-    assert collections == {
-        'shelves/{shelf}/books/{book}': {
-            'entity_name': 'book',
-            'name_pattern': 'shelves/{shelf}/books/{book}'
-        },
-        'archives/{archive}/books/{book}': {
-            'entity_name': 'archive_book',
-            'name_pattern': 'archives/{archive}/books/{book}'
-        }
-    }
+    gapic_utils.update_collections(res, collections, collection_oneofs)
+    assert collections == {}
     assert collection_oneofs == {
         'book_oneof': {
-            'collection_names': ['book', 'archive_book'],
+            'collection_names': [],
             'oneof_name': 'book_oneof'
         }
     }
 
+def test_update_collections_single_pattern():
+    res = resource_pb2.ResourceDescriptor()
+    res.type = 'test/Book'
+    res.pattern.append("shelves/{shelf}/books/{book}")
+
+    collections = {}
+    collection_oneofs = {}
+    gapic_utils.update_collections(res, collections, collection_oneofs)
+    assert collections == {
+        'book': {
+            'entity_name': 'book',
+            'name_pattern': 'shelves/{shelf}/books/{book}'
+        }
+    }
+    assert collection_oneofs == {}
 
 def test_library_gapic_v1():
 
@@ -165,7 +112,7 @@ def test_library_gapic_v1():
     assert [r for r in resource_name_artifacts if
             type(r) is resource_name.ResourceNameFixed
             and r.fixed_value == '_deleted-book_'
-            and r.format_name_upper == 'DeletedBook']
+            and r.class_name == 'DeletedBook']
     assert [r for r in resource_name_artifacts if
             type(r) is resource_name.ParentResourceName
             and r.class_name == 'BookName']
@@ -178,7 +125,8 @@ def test_library_gapic_v2():
 
     request = plugin_pb2.CodeGeneratorRequest()
     proto_files = ["test/testdata/library_simple.proto",
-                   "test/testdata/archive.proto"]
+                   "test/testdata/archive.proto",
+                   "test/testdata/common_resources.proto"]
     request.file_to_generate.extend(proto_files)
     request.parameter = "test/testdata/library_gapic_v2.yaml"
 
@@ -202,7 +150,7 @@ def test_library_gapic_v2():
 
     reconstructed_gapic_config = gapic_utils.reconstruct_gapic_yaml(
         gapic_yaml, request)
-    assert reconstructed_gapic_config['collections'] == [
+    assert [c for c in [
         {
             'name_pattern': 'projects/{project}/shelves/{shelf}/books/{book}',
             'language_overrides': [
@@ -237,7 +185,15 @@ def test_library_gapic_v2():
                 'publishers/{publisher}',
             'entity_name': 'publisher',
         },
-    ]
+        {
+            'entity_name': 'location',
+            'name_pattern': 'projects/{project}/locations/{location}'
+        },
+        {
+            'entity_name': 'folder',
+            'name_pattern': 'folders/{folder}'
+        },
+    ] if c in reconstructed_gapic_config['collections']]
     assert reconstructed_gapic_config['collection_oneofs'] == [
         {
             'collection_names': ['book', 'archive_book', 'deleted_book'],
@@ -268,7 +224,7 @@ def test_library_gapic_v2():
     assert [r for r in resource_name_artifacts if
             type(r) is resource_name.ResourceNameFixed
             and r.fixed_value == '_deleted-book_'
-            and r.format_name_upper == 'DeletedBook'
+            and r.class_name == 'DeletedBook'
             and r.parent_interface == 'BookName']
     assert [r for r in resource_name_artifacts if
             type(r) is resource_name.ParentResourceName

--- a/test/testdata/java_archived_book_name.baseline
+++ b/test/testdata/java_archived_book_name.baseline
@@ -24,6 +24,7 @@ import java.util.List;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 @javax.annotation.Generated("by GAPIC protoc plugin")
+@Deprecated This resource name class will be removed in the next major version.
 public class ArchivedBookName extends BookName {
 
   private static final PathTemplate PATH_TEMPLATE =

--- a/test/testdata/java_archived_book_name.baseline
+++ b/test/testdata/java_archived_book_name.baseline
@@ -22,9 +22,13 @@ import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
 
-// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ *
+ * @deprecated This resource name class will be removed in the next major version.
+ */
 @javax.annotation.Generated("by GAPIC protoc plugin")
-@Deprecated This resource name class will be removed in the next major version.
+@Deprecated
 public class ArchivedBookName extends BookName {
 
   private static final PathTemplate PATH_TEMPLATE =

--- a/test/testdata/java_book_name.baseline
+++ b/test/testdata/java_book_name.baseline
@@ -16,7 +16,9 @@ package com.google.example.library.v1;
 
 import com.google.api.resourcenames.ResourceName;
 
-// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ */
 @javax.annotation.Generated("by GAPIC protoc plugin")
 public abstract class BookName implements ResourceName {
   protected BookName() {}

--- a/test/testdata/java_book_names.baseline
+++ b/test/testdata/java_book_names.baseline
@@ -16,9 +16,13 @@ package com.google.example.library.v1;
 
 import com.google.api.resourcenames.ResourceName;
 
-// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ *
+ * @deprecated This resource name class will be removed in the next major version.
+ */
 @javax.annotation.Generated("by GAPIC protoc plugin")
-@Deprecated This resource name class will be removed in the next major version.
+@Deprecated
 public class BookNames {
   private BookNames() {}
 

--- a/test/testdata/java_book_names.baseline
+++ b/test/testdata/java_book_names.baseline
@@ -18,6 +18,7 @@ import com.google.api.resourcenames.ResourceName;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 @javax.annotation.Generated("by GAPIC protoc plugin")
+@Deprecated This resource name class will be removed in the next major version.
 public class BookNames {
   private BookNames() {}
 

--- a/test/testdata/java_deleted_book.baseline
+++ b/test/testdata/java_deleted_book.baseline
@@ -20,6 +20,7 @@ import java.util.Map;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 @javax.annotation.Generated("by GAPIC protoc plugin")
+@Deprecated This resource name class will be removed in the next major version.
 public class DeletedBook extends BookName {
 
   private static final String FIXED_VALUE = "_deleted-book_";

--- a/test/testdata/java_deleted_book.baseline
+++ b/test/testdata/java_deleted_book.baseline
@@ -18,9 +18,13 @@ import com.google.api.resourcenames.ResourceName;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 
-// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ *
+ * @deprecated This resource name class will be removed in the next major version.
+ */
 @javax.annotation.Generated("by GAPIC protoc plugin")
-@Deprecated This resource name class will be removed in the next major version.
+@Deprecated
 public class DeletedBook extends BookName {
 
   private static final String FIXED_VALUE = "_deleted-book_";

--- a/test/testdata/java_folder_name.baseline
+++ b/test/testdata/java_folder_name.baseline
@@ -22,7 +22,9 @@ import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
 
-// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ */
 @javax.annotation.Generated("by GAPIC protoc plugin")
 public class FolderName implements ResourceName {
 

--- a/test/testdata/java_location_name.baseline
+++ b/test/testdata/java_location_name.baseline
@@ -22,7 +22,9 @@ import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
 
-// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ */
 @javax.annotation.Generated("by GAPIC protoc plugin")
 public class LocationName implements ResourceName {
 

--- a/test/testdata/java_project_name.baseline
+++ b/test/testdata/java_project_name.baseline
@@ -22,7 +22,9 @@ import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
 
-// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ */
 @javax.annotation.Generated("by GAPIC protoc plugin")
 public class ProjectName implements ResourceName {
 

--- a/test/testdata/java_publisher_name.baseline
+++ b/test/testdata/java_publisher_name.baseline
@@ -22,7 +22,9 @@ import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
 
-// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ */
 @javax.annotation.Generated("by GAPIC protoc plugin")
 public class PublisherName implements ResourceName {
 

--- a/test/testdata/java_shelf_book_name.baseline
+++ b/test/testdata/java_shelf_book_name.baseline
@@ -22,9 +22,13 @@ import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
 
-// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ *
+ * @deprecated This resource name class will be removed in the next major version.
+ */
 @javax.annotation.Generated("by GAPIC protoc plugin")
-@Deprecated This resource name class will be removed in the next major version.
+@Deprecated
 public class ShelfBookName extends BookName {
 
   private static final PathTemplate PATH_TEMPLATE =

--- a/test/testdata/java_shelf_book_name.baseline
+++ b/test/testdata/java_shelf_book_name.baseline
@@ -24,6 +24,7 @@ import java.util.List;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 @javax.annotation.Generated("by GAPIC protoc plugin")
+@Deprecated This resource name class will be removed in the next major version.
 public class ShelfBookName extends BookName {
 
   private static final PathTemplate PATH_TEMPLATE =

--- a/test/testdata/java_shelf_name.baseline
+++ b/test/testdata/java_shelf_name.baseline
@@ -22,7 +22,9 @@ import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
 
-// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ */
 @javax.annotation.Generated("by GAPIC protoc plugin")
 public class ShelfName implements ResourceName {
 

--- a/test/testdata/java_untyped_book_name.baseline
+++ b/test/testdata/java_untyped_book_name.baseline
@@ -23,6 +23,7 @@ import java.util.Map;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 @javax.annotation.Generated("by GAPIC protoc plugin")
+@Deprecated This resource name class will be removed in the next major version.
 public class UntypedBookName extends BookName {
 
   private final String rawValue;

--- a/test/testdata/java_untyped_book_name.baseline
+++ b/test/testdata/java_untyped_book_name.baseline
@@ -21,9 +21,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ *
+ * @deprecated This resource name class will be removed in the next major version.
+ */
 @javax.annotation.Generated("by GAPIC protoc plugin")
-@Deprecated This resource name class will be removed in the next major version.
+@Deprecated
 public class UntypedBookName extends BookName {
 
   private final String rawValue;

--- a/test/testdata/library_gapic_v1.yaml
+++ b/test/testdata/library_gapic_v1.yaml
@@ -25,4 +25,3 @@ interfaces:
             entity_name: shelf_book
       - name_pattern: archives/{archive_id}/books/{book_id=**}
         entity_name: archived_book
-

--- a/test/testdata/library_gapic_v2.yaml
+++ b/test/testdata/library_gapic_v2.yaml
@@ -1,11 +1,17 @@
 type: com.google.api.codegen.ConfigProto
 config_schema_version: 2.0.0
-collections:
-  - entity_name: book
-    language_overrides:
-      - language: java
-        entity_name: shelf_book
-  - entity_name: archive_book
-    language_overrides:
-    - language: java
-      entity_name: archived_book
+interfaces:
+  - name: google.example.library.v1.LibraryService
+    deprecated_collections:
+      - name_pattern: "projects/{project}/shelves/{shelf}/books/{book}"
+        entity_name: book
+        language_overrides:
+          - language: java
+            entity_name: shelf_book
+      - name_pattern: "archives/{archive}/books/{book}"
+        entity_name: archive_book
+        language_overrides:
+          - language: java
+            entity_name: archived_book
+      - name_pattern: _deleted-book_
+        entity_name: deleted_book


### PR DESCRIPTION
- Support `deprecated_collections` in gapic config v2. If the pattern of a `deprecated_collection` belong to a multi-pattern resource in proto files, generate a resource name class based on the entity_name and the pattern and mark the generated class as deprecated. This way we won't break existing clients with multi-pattern resource names.

- Stop generating entity names from patterns by constructing a trie. We do not need it in the new generated multi-pattern resource name.

- Stop guessing the parent resource of a resource referenced by `child_type`. We only generate the resource if there is a parent resource explicitly defined in the protos, with each of whose pattern(s) is a parent of each of the pattern(s) of the resource referenced by `child_type`. This is consistent with C# micro generator, and with the file-level annotations we shouldn't need to guess the parent resource any more.

- Remove google-gax as a dependency since it does not seem to be used any more.