### PR TITLE
Drop Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 before_script:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,pep8,pylint-errors
+envlist = py27,py35,py36,pep8,pylint-errors
 skipsdist = True
 
 [tox:travis]


### PR DESCRIPTION
PyYAML now requires Python 3.5+: https://pyyaml.org/wiki/PyYAML
This causes testing against Python 3.4 in travis to fail: https://travis-ci.org/googleapis/protoc-java-resource-names-plugin/jobs/633984056?utm_medium=notification&utm_source=github_status