### PR TITLE
Collect all message-level resources even if they are not referenced

### DIFF
--- a/plugin/utils/gapic_utils.py
+++ b/plugin/utils/gapic_utils.py
@@ -157,7 +157,7 @@ def create_gapic_config_v2(gapic_v2, request):  # noqa: C901
         request)
     type_resource_map, pattern_resource_map = get_all_resources(request)
 
-    # Put all referenced single-pattern resources defined in protos to 
+    # Put all referenced single-pattern resources defined in protos to
     # collections and all multi-pattern resources defined in protos to
     # collection_oneofs.
     #

--- a/test/test_plugin_baseline.py
+++ b/test/test_plugin_baseline.py
@@ -123,7 +123,7 @@ def run_protoc_V2():
 RESOURCE_NAMES_TO_GENERATE = ['shelf_book_name', 'shelf_name',
                               'archived_book_name', 'deleted_book',
                               'folder_name', 'location_name',
-                              'publisher_name']
+                              'publisher_name', "archive_name"]
 ONEOFS_TO_GENERATE = ['book_oneof']
 
 PROTOC_OUTPUT_DIR = os.path.join('com', 'google', 'example', 'library', 'v1')

--- a/test/testdata/gapic/java_archive_name.baseline
+++ b/test/testdata/gapic/java_archive_name.baseline
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.example.library.v1;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.api.resourcenames.ResourceName;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ */
+@javax.annotation.Generated("by GAPIC protoc plugin")
+public class ArchiveName implements ResourceName {
+
+  private static final PathTemplate PATH_TEMPLATE =
+      PathTemplate.createWithoutUrlEncoding("projects/{project}/locations/{location}/archives/{archive}");
+
+  private volatile Map<String, String> fieldValuesMap;
+
+  private final String project;
+  private final String location;
+  private final String archive;
+
+  public String getProject() {
+    return project;
+  }
+
+  public String getLocation() {
+    return location;
+  }
+
+  public String getArchive() {
+    return archive;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  private ArchiveName(Builder builder) {
+    project = Preconditions.checkNotNull(builder.getProject());
+    location = Preconditions.checkNotNull(builder.getLocation());
+    archive = Preconditions.checkNotNull(builder.getArchive());
+  }
+
+  public static ArchiveName of(String project, String location, String archive) {
+    return newBuilder()
+      .setProject(project)
+      .setLocation(location)
+      .setArchive(archive)
+      .build();
+  }
+
+  public static String format(String project, String location, String archive) {
+    return newBuilder()
+      .setProject(project)
+      .setLocation(location)
+      .setArchive(archive)
+      .build()
+      .toString();
+  }
+
+  public static ArchiveName parse(String formattedString) {
+    if (formattedString.isEmpty()) {
+      return null;
+    }
+    Map<String, String> matchMap =
+        PATH_TEMPLATE.validatedMatch(formattedString, "ArchiveName.parse: formattedString not in valid format");
+    return of(matchMap.get("project"), matchMap.get("location"), matchMap.get("archive"));
+  }
+
+  public static List<ArchiveName> parseList(List<String> formattedStrings) {
+    List<ArchiveName> list = new ArrayList<>(formattedStrings.size());
+    for (String formattedString : formattedStrings) {
+      list.add(parse(formattedString));
+    }
+    return list;
+  }
+
+  public static List<String> toStringList(List<ArchiveName> values) {
+    List<String> list = new ArrayList<String>(values.size());
+    for (ArchiveName value : values) {
+      if (value == null) {
+        list.add("");
+      } else {
+        list.add(value.toString());
+      }
+    }
+    return list;
+  }
+
+  public static boolean isParsableFrom(String formattedString) {
+    return PATH_TEMPLATE.matches(formattedString);
+  }
+
+  public Map<String, String> getFieldValuesMap() {
+    if (fieldValuesMap == null) {
+      synchronized (this) {
+        if (fieldValuesMap == null) {
+          ImmutableMap.Builder<String, String> fieldMapBuilder = ImmutableMap.builder();
+          fieldMapBuilder.put("project", project);
+          fieldMapBuilder.put("location", location);
+          fieldMapBuilder.put("archive", archive);
+          fieldValuesMap = fieldMapBuilder.build();
+        }
+      }
+    }
+    return fieldValuesMap;
+  }
+
+  public String getFieldValue(String fieldName) {
+    return getFieldValuesMap().get(fieldName);
+  }
+
+  @Override
+  public String toString() {
+    return PATH_TEMPLATE.instantiate("project", project, "location", location, "archive", archive);
+  }
+
+  /** Builder for ArchiveName. */
+  public static class Builder {
+
+    private String project;
+    private String location;
+    private String archive;
+
+    public String getProject() {
+      return project;
+    }
+
+    public String getLocation() {
+      return location;
+    }
+
+    public String getArchive() {
+      return archive;
+    }
+
+    public Builder setProject(String project) {
+      this.project = project;
+      return this;
+    }
+
+    public Builder setLocation(String location) {
+      this.location = location;
+      return this;
+    }
+
+    public Builder setArchive(String archive) {
+      this.archive = archive;
+      return this;
+    }
+
+    private Builder() {
+    }
+
+    private Builder(ArchiveName archiveName) {
+      project = archiveName.project;
+      location = archiveName.location;
+      archive = archiveName.archive;
+    }
+
+    public ArchiveName build() {
+      return new ArchiveName(this);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof ArchiveName) {
+      ArchiveName that = (ArchiveName) o;
+      return (this.project.equals(that.project))
+          && (this.location.equals(that.location))
+          && (this.archive.equals(that.archive));
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= project.hashCode();
+    h *= 1000003;
+    h ^= location.hashCode();
+    h *= 1000003;
+    h ^= archive.hashCode();
+    return h;
+  }
+}
+

--- a/test/testdata/library_gapic.yaml
+++ b/test/testdata/library_gapic.yaml
@@ -2,9 +2,6 @@ type: com.google.api.codegen.ConfigProto
 #language_settings: <snip>
 #license_header: <snip>
 config_schema_version: 1.0.0
-collections:
-  - name_pattern: archives/{archive}/books/{book}
-    entity_name: archive_book
 collection_oneofs:
   - oneof_name: book_oneof
     collection_names:
@@ -12,6 +9,8 @@ collection_oneofs:
     - archive_book
     - deleted_book
 collections:
+- name_pattern: projects/{project}/locations/{location}/archives/{archive}
+  entity_name: archive
 - name_pattern: projects/{project}
   entity_name: project
   language_overrides:

--- a/test/testdata/library_simple.proto
+++ b/test/testdata/library_simple.proto
@@ -247,3 +247,12 @@ message SeriesUuid {
     string series_string = 2;
   }
 }
+
+message Archive {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Archive",
+    pattern: "projects/{project}/locations/{location}/archives/{archive}"
+  };
+
+  string name = 1;
+}

--- a/test/testdata/protoannotation/java_archive_name.baseline
+++ b/test/testdata/protoannotation/java_archive_name.baseline
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.example.library.v1;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.api.resourcenames.ResourceName;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ */
+@javax.annotation.Generated("by GAPIC protoc plugin")
+public class ArchiveName implements ResourceName {
+
+  private static final PathTemplate PATH_TEMPLATE =
+      PathTemplate.createWithoutUrlEncoding("projects/{project}/locations/{location}/archives/{archive}");
+
+  private volatile Map<String, String> fieldValuesMap;
+
+  private final String project;
+  private final String location;
+  private final String archive;
+
+  public String getProject() {
+    return project;
+  }
+
+  public String getLocation() {
+    return location;
+  }
+
+  public String getArchive() {
+    return archive;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  private ArchiveName(Builder builder) {
+    project = Preconditions.checkNotNull(builder.getProject());
+    location = Preconditions.checkNotNull(builder.getLocation());
+    archive = Preconditions.checkNotNull(builder.getArchive());
+  }
+
+  public static ArchiveName of(String project, String location, String archive) {
+    return newBuilder()
+      .setProject(project)
+      .setLocation(location)
+      .setArchive(archive)
+      .build();
+  }
+
+  public static String format(String project, String location, String archive) {
+    return newBuilder()
+      .setProject(project)
+      .setLocation(location)
+      .setArchive(archive)
+      .build()
+      .toString();
+  }
+
+  public static ArchiveName parse(String formattedString) {
+    if (formattedString.isEmpty()) {
+      return null;
+    }
+    Map<String, String> matchMap =
+        PATH_TEMPLATE.validatedMatch(formattedString, "ArchiveName.parse: formattedString not in valid format");
+    return of(matchMap.get("project"), matchMap.get("location"), matchMap.get("archive"));
+  }
+
+  public static List<ArchiveName> parseList(List<String> formattedStrings) {
+    List<ArchiveName> list = new ArrayList<>(formattedStrings.size());
+    for (String formattedString : formattedStrings) {
+      list.add(parse(formattedString));
+    }
+    return list;
+  }
+
+  public static List<String> toStringList(List<ArchiveName> values) {
+    List<String> list = new ArrayList<String>(values.size());
+    for (ArchiveName value : values) {
+      if (value == null) {
+        list.add("");
+      } else {
+        list.add(value.toString());
+      }
+    }
+    return list;
+  }
+
+  public static boolean isParsableFrom(String formattedString) {
+    return PATH_TEMPLATE.matches(formattedString);
+  }
+
+  public Map<String, String> getFieldValuesMap() {
+    if (fieldValuesMap == null) {
+      synchronized (this) {
+        if (fieldValuesMap == null) {
+          ImmutableMap.Builder<String, String> fieldMapBuilder = ImmutableMap.builder();
+          fieldMapBuilder.put("project", project);
+          fieldMapBuilder.put("location", location);
+          fieldMapBuilder.put("archive", archive);
+          fieldValuesMap = fieldMapBuilder.build();
+        }
+      }
+    }
+    return fieldValuesMap;
+  }
+
+  public String getFieldValue(String fieldName) {
+    return getFieldValuesMap().get(fieldName);
+  }
+
+  @Override
+  public String toString() {
+    return PATH_TEMPLATE.instantiate("project", project, "location", location, "archive", archive);
+  }
+
+  /** Builder for ArchiveName. */
+  public static class Builder {
+
+    private String project;
+    private String location;
+    private String archive;
+
+    public String getProject() {
+      return project;
+    }
+
+    public String getLocation() {
+      return location;
+    }
+
+    public String getArchive() {
+      return archive;
+    }
+
+    public Builder setProject(String project) {
+      this.project = project;
+      return this;
+    }
+
+    public Builder setLocation(String location) {
+      this.location = location;
+      return this;
+    }
+
+    public Builder setArchive(String archive) {
+      this.archive = archive;
+      return this;
+    }
+
+    private Builder() {
+    }
+
+    private Builder(ArchiveName archiveName) {
+      project = archiveName.project;
+      location = archiveName.location;
+      archive = archiveName.archive;
+    }
+
+    public ArchiveName build() {
+      return new ArchiveName(this);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof ArchiveName) {
+      ArchiveName that = (ArchiveName) o;
+      return (this.project.equals(that.project))
+          && (this.location.equals(that.location))
+          && (this.archive.equals(that.archive));
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= project.hashCode();
+    h *= 1000003;
+    h ^= location.hashCode();
+    h *= 1000003;
+    h ^= archive.hashCode();
+    return h;
+  }
+}
+


### PR DESCRIPTION
We need to generate resource name helpers for those defined at message level even if they are not referenced, because they already have proto messages linked to them (the messages where they are defined).