### PR TITLE
add support for generating all resource classes referenced in child_type

### DIFF
--- a/plugin/utils/gapic_utils.py
+++ b/plugin/utils/gapic_utils.py
@@ -298,7 +298,7 @@ def get_all_resource_references(request):
 
 def get_parent_resources(res, pattern_map, all_resources):
     """ Return the parent resources of res.
-    We consider the list of resources to be another resource Foo's parents 
+    We consider the list of resources to be another resource Foo's parents
     if the union of all patterns in the list have one-to-one parent-child
     mapping with Foo's patterns.
     """
@@ -311,12 +311,13 @@ def get_parent_resources(res, pattern_map, all_resources):
                                                    [],
                                                    len(res.pattern),
                                                    i)
-        if parent_resources != None:
+        if parent_resources is not None:
             return parent_resources
 
     return []
 
-def _match_parent_resources(parent_patterns_map, all_resources, 
+
+def _match_parent_resources(parent_patterns_map, all_resources,
                             matched_parent_resources, unmatched_count, i):
     # We make a copy to advance in the depth-first search. There won't be
     # too many patterns in a resource so performance-wise it is not a problem.
@@ -325,19 +326,24 @@ def _match_parent_resources(parent_patterns_map, all_resources,
     for pattern in resource_to_match.pattern:
         if pattern not in parent_patterns_map_copy:
             return None
-        if parent_patterns_map_copy[pattern] == False:
+        if not parent_patterns_map_copy[pattern]:
             unmatched_count -= 1;
             parent_patterns_map_copy[pattern] = True
     matched_parent_resources.append(resource_to_match)
     if unmatched_count == 0:
         return copy.copy(matched_parent_resources)
     for j in range(i + 1, len(all_resources)):
-        answer = _match_parent_resources(parent_patterns_map_copy, all_resources, matched_parent_resources, unmatched_count, j)
+        answer = _match_parent_resources(parent_patterns_map_copy,
+                                         all_resources,
+                                         matched_parent_resources,
+                                         unmatched_count,
+                                         j)
         # We stop when we find the first list of matched parent resources
         if answer is not None:
             return answer
     matched_parent_resources.pop()
     return None
+
 
 def update_collections(res, collections, collection_oneofs):
     # Determine the name.

--- a/plugin/utils/gapic_utils.py
+++ b/plugin/utils/gapic_utils.py
@@ -327,7 +327,7 @@ def _match_parent_resources(parent_patterns_map, all_resources,
         if pattern not in parent_patterns_map_copy:
             return None
         if not parent_patterns_map_copy[pattern]:
-            unmatched_count -= 1;
+            unmatched_count -= 1
             parent_patterns_map_copy[pattern] = True
     matched_parent_resources.append(resource_to_match)
     if unmatched_count == 0:

--- a/plugin/utils/gapic_utils.py
+++ b/plugin/utils/gapic_utils.py
@@ -170,8 +170,10 @@ def create_gapic_config_v2(gapic_v2, request):  # noqa: C901
             update_collections(res, collections, collection_oneofs)
 
         if type in types_with_child_references:
-            parent_res = get_parent_resource(res, pattern_resource_map)
-            if parent_res is not None:
+            parent_resources = \
+                get_parent_resources(res, pattern_resource_map,
+                                     list(type_resource_map.values()))
+            for parent_res in parent_resources:
                 update_collections(parent_res, collections, collection_oneofs)
 
     # Collect all message-level resources regardless of whether they
@@ -294,31 +296,48 @@ def get_all_resource_references(request):
     return types_with_ref, types_with_child_references
 
 
-def get_parent_resource(res, pattern_map):
-    """ Return the parent resource of res.
-    We consider resource Foo to be resource Bar's parent iff Foo and Bar have
-    the same number of patterns, and for each pattern 'B' in Bar, there is
-    a pattern 'F' in Foo , such that 'F' is the parent 'B'.
-    Returns None if we can't find the parent of res.
+def get_parent_resources(res, pattern_map, all_resources):
+    """ Return the parent resources of res.
+    We consider the list of resources to be another resource Foo's parents 
+    if the union of all patterns in the list have one-to-one parent-child
+    mapping with Foo's patterns.
     """
-    parent_candidates = []
     parent_patterns = build_parent_patterns(res.pattern)
-    for parent_pattern in parent_patterns:
-        if parent_pattern not in pattern_map:
+    parent_patterns_map = {pattern: False for pattern in parent_patterns}
+
+    for i in range(0, len(all_resources)):
+        parent_resources = _match_parent_resources(parent_patterns_map,
+                                                   all_resources,
+                                                   [],
+                                                   len(res.pattern),
+                                                   i)
+        if parent_resources != None:
+            return parent_resources
+
+    return []
+
+def _match_parent_resources(parent_patterns_map, all_resources, 
+                            matched_parent_resources, unmatched_count, i):
+    # We make a copy to advance in the depth-first search. There won't be
+    # too many patterns in a resource so performance-wise it is not a problem.
+    parent_patterns_map_copy = copy.copy(parent_patterns_map)
+    resource_to_match = all_resources[i]
+    for pattern in resource_to_match.pattern:
+        if pattern not in parent_patterns_map_copy:
             return None
-        if not parent_candidates:
-            parent_candidates = pattern_map[parent_pattern]
-        else:
-            parent_candidates = [r for r in parent_candidates
-                                 if r in pattern_map[parent_pattern]]
-
-    if not parent_candidates:
-        return None
-    if len(parent_candidates) == 1:
-        return parent_candidates[0]
-    raise ValueError('Found multiple parent '
-                     'resources: {}'.format(parent_candidates))
-
+        if parent_patterns_map_copy[pattern] == False:
+            unmatched_count -= 1;
+            parent_patterns_map_copy[pattern] = True
+    matched_parent_resources.append(resource_to_match)
+    if unmatched_count == 0:
+        return copy.copy(matched_parent_resources)
+    for j in range(i + 1, len(all_resources)):
+        answer = _match_parent_resources(parent_patterns_map_copy, all_resources, matched_parent_resources, unmatched_count, j)
+        # We stop when we find the first list of matched parent resources
+        if answer is not None:
+            return answer
+    matched_parent_resources.pop()
+    return None
 
 def update_collections(res, collections, collection_oneofs):
     # Determine the name.
@@ -449,6 +468,8 @@ def find_single_and_fixed_entities(all_resource_names):
     fixed_entities = []
 
     for collection in all_resource_names:
+        if 'name_pattern' not in collection:
+            continue
         name_pattern = collection['name_pattern']
         if isFixedPattern(name_pattern):
             fixed_entities.append(collection)

--- a/test/test_gapic_utils.py
+++ b/test/test_gapic_utils.py
@@ -89,7 +89,8 @@ def test_get_parent_resources_single_pattern():
         "shelves/{shelf}/books/{book}": [book],
         "shelves/{shelf}": [shelf]
     }
-    assert shelf == gapic_utils.get_parent_resource(book, pattern_map)
+    all_resources = [book, shelf]
+    assert shelf == gapic_utils.get_parent_resources(book, pattern_map, all_resources)[0]
 
 
 def test_get_parent_resources_multi_pattern():
@@ -113,7 +114,8 @@ def test_get_parent_resources_multi_pattern():
         "shelves/{shelf}": [parent],
         "projects/{project}": [parent]
     }
-    assert parent == gapic_utils.get_parent_resource(book, pattern_map)
+    all_resources = [parent, shelf, book]
+    assert parent == gapic_utils.get_parent_resources(book, pattern_map, all_resources)[0]
 
 
 def test_get_parent_resources_multi_pattern_fail():
@@ -137,7 +139,8 @@ def test_get_parent_resources_multi_pattern_fail():
         "projects/{project}/books/{book}": [book],
         "shelves/{shelf}": [parent],
     }
-    assert gapic_utils.get_parent_resource(book, pattern_map) is None
+    all_resources = [book, parent]
+    assert len(gapic_utils.get_parent_resources(book, pattern_map, all_resources)) == 0
 
 
 def test_update_collections_with_deprecated_collections():
@@ -305,10 +308,17 @@ def test_library_gapic_v2():
             and r.class_name == 'DeletedBook'
             and r.parent_interface == 'BookName']
 
-    for r in resource_name_artifacts:
-        if type(r) is resource_name.ParentResourceName:
-            assert r.has_fixed_patterns is True \
-                and r.has_formattable_patterns is True
+    assert [r for r in resource_name_artifacts if
+            type(r) is resource_name.ParentResourceName
+            and r.class_name == "BookName"
+            and r.has_fixed_patterns is True 
+            and r.has_formattable_patterns is True]
+
+    assert [r for r in resource_name_artifacts if
+            type(r) is resource_name.ParentResourceName
+            and r.class_name == "ArchiveName"
+            and r.has_fixed_patterns is False 
+            and r.has_formattable_patterns is True]
 
     assert [r for r in resource_name_artifacts if
             type(r) is resource_name.ParentResourceName

--- a/test/test_gapic_utils.py
+++ b/test/test_gapic_utils.py
@@ -90,7 +90,8 @@ def test_get_parent_resources_single_pattern():
         "shelves/{shelf}": [shelf]
     }
     all_resources = [book, shelf]
-    assert shelf == gapic_utils.get_parent_resources(book, pattern_map, all_resources)[0]
+    assert shelf == gapic_utils.get_parent_resources(
+        book, pattern_map, all_resources)[0]
 
 
 def test_get_parent_resources_multi_pattern():
@@ -115,7 +116,33 @@ def test_get_parent_resources_multi_pattern():
         "projects/{project}": [parent]
     }
     all_resources = [parent, shelf, book]
-    assert parent == gapic_utils.get_parent_resources(book, pattern_map, all_resources)[0]
+    assert parent == gapic_utils.get_parent_resources(
+        book, pattern_map, all_resources)[0]
+
+
+def test_get_parent_resources_multi_references():
+    book = resource_pb2.ResourceDescriptor()
+    book.type = 'test/Book'
+    book.pattern.append("shelves/{shelf}/books/{book}")
+    book.pattern.append("projects/{project}/books/{book}")
+
+    shelf = resource_pb2.ResourceDescriptor()
+    shelf.type = 'test/Shelf'
+    shelf.pattern.append("shelves/{shelf}")
+
+    project = resource_pb2.ResourceDescriptor()
+    project.type = 'test/Project'
+    project.pattern.append("projects/{project}")
+
+    pattern_map = {
+        "shelves/{shelf}/books/{book}": [book],
+        "projects/{project}/books/{book}": [book],
+        "shelves/{shelf}": [shelf],
+        "projects/{project}": [project]
+    }
+    all_resources = [project, shelf, book]
+    assert [project, shelf] == gapic_utils.get_parent_resources(
+        book, pattern_map, all_resources)
 
 
 def test_get_parent_resources_multi_pattern_fail():
@@ -140,7 +167,8 @@ def test_get_parent_resources_multi_pattern_fail():
         "shelves/{shelf}": [parent],
     }
     all_resources = [book, parent]
-    assert len(gapic_utils.get_parent_resources(book, pattern_map, all_resources)) == 0
+    assert len(gapic_utils.get_parent_resources(
+        book, pattern_map, all_resources)) == 0
 
 
 def test_update_collections_with_deprecated_collections():
@@ -311,7 +339,7 @@ def test_library_gapic_v2():
     assert [r for r in resource_name_artifacts if
             type(r) is resource_name.ParentResourceName
             and r.class_name == "BookName"
-            and r.has_fixed_patterns is True 
+            and r.has_fixed_patterns is True
             and r.has_formattable_patterns is True]
 
     assert [r for r in resource_name_artifacts if

--- a/test/test_gapic_utils.py
+++ b/test/test_gapic_utils.py
@@ -345,7 +345,7 @@ def test_library_gapic_v2():
     assert [r for r in resource_name_artifacts if
             type(r) is resource_name.ParentResourceName
             and r.class_name == "ArchiveName"
-            and r.has_fixed_patterns is False 
+            and r.has_fixed_patterns is False
             and r.has_formattable_patterns is True]
 
     assert [r for r in resource_name_artifacts if

--- a/test/test_plugin_baseline.py
+++ b/test/test_plugin_baseline.py
@@ -189,14 +189,14 @@ class TestProtocGapicPlugin(object):
 class TestProtocGapicPluginV2(object):
 
     @pytest.mark.parametrize('resource',
-                             RESOURCE_NAMES_TO_GENERATE + ["project_name"])
+                             RESOURCE_NAMES_TO_GENERATE + ["project_name", "organization_name"])
     def test_resource_name_generation(self, run_protoc_V2, resource):
         generated_class = casing_utils.lower_underscore_to_upper_camel(
             resource)
         check_output(generated_class, TEST_OUTPUT_DIR_V2, PROTOC_OUTPUT_DIR,
                      TEST_DIR_GAPIC_V2, 'java_' + resource)
 
-    @pytest.mark.parametrize('oneof', ONEOFS_TO_GENERATE)
+    @pytest.mark.parametrize('oneof', ONEOFS_TO_GENERATE + ["archive_oneof"])
     def test_parent_resource_name_generation(self, run_protoc_V2, oneof):
         generated_parent = \
             casing_utils.get_parent_resource_name_class_name(oneof)
@@ -208,7 +208,7 @@ class TestProtocGapicPluginV2(object):
                      TEST_DIR_GAPIC_V2,
                      'java_' + parent_filename_fragment)
 
-    @pytest.mark.parametrize('oneof', ONEOFS_TO_GENERATE)
+    @pytest.mark.parametrize('oneof', ONEOFS_TO_GENERATE + ["archive_oneof"])
     def test_untyped_resource_name_generation(self, run_protoc_V2, oneof):
         generated_untyped = \
             casing_utils.get_untyped_resource_name_class_name(oneof)
@@ -220,7 +220,7 @@ class TestProtocGapicPluginV2(object):
                      TEST_DIR_GAPIC_V2,
                      'java_' + untyped_filename_fragment)
 
-    @pytest.mark.parametrize('oneof', ONEOFS_TO_GENERATE)
+    @pytest.mark.parametrize('oneof', ONEOFS_TO_GENERATE + ["archive_oneof"])
     def test_resource_name_factory_generation(self, run_protoc_V2, oneof):
         generated_parent = \
             casing_utils.get_resource_name_factory_class_name(oneof)

--- a/test/test_plugin_baseline.py
+++ b/test/test_plugin_baseline.py
@@ -189,7 +189,8 @@ class TestProtocGapicPlugin(object):
 class TestProtocGapicPluginV2(object):
 
     @pytest.mark.parametrize('resource',
-                             RESOURCE_NAMES_TO_GENERATE + ["project_name", "organization_name"])
+                             RESOURCE_NAMES_TO_GENERATE +
+                             ["project_name", "organization_name"])
     def test_resource_name_generation(self, run_protoc_V2, resource):
         generated_class = casing_utils.lower_underscore_to_upper_camel(
             resource)

--- a/test/testdata/library_simple.proto
+++ b/test/testdata/library_simple.proto
@@ -59,6 +59,17 @@ service LibraryService {
       }
     };
   }
+
+  rpc CreateArchive(CreateArchiveRequest) returns (Archive) {
+    option (google.api.http) = {
+      post: "v1/{parent=projects/*}/archives"
+      body: "archive"
+      additional_bindings: {
+        post: "/v1/{parent=projects/*locations/*}/archives"
+        body: "archives"
+      }
+    };
+  }
 }
 
 // A single book in the library.
@@ -241,6 +252,14 @@ message PublishSeriesResponse {
   SeriesUuid series_uuid = 3;
 }
 
+message CreateArchiveRequest {
+
+  string parent = 1 [
+    (google.api.resource_reference).child_type = "library.googleapis.com/Archive"];
+
+  Archive archive = 2;
+}
+
 message SeriesUuid {
   oneof source {
     bytes series_bytes = 1;
@@ -252,6 +271,7 @@ message Archive {
   option (google.api.resource) = {
     type: "library.googleapis.com/Archive",
     pattern: "projects/{project}/locations/{location}/archives/{archive}"
+    pattern: "organizations/{organization}/archives/{archive}"
   };
 
   string name = 1;

--- a/test/testdata/protoannotation/java_archive_name.baseline
+++ b/test/testdata/protoannotation/java_archive_name.baseline
@@ -16,26 +16,37 @@ package com.google.example.library.v1;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.api.core.BetaApi;
 import com.google.api.pathtemplate.PathTemplate;
+import com.google.api.pathtemplate.ValidationException;
 import com.google.api.resourcenames.ResourceName;
 import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * AUTO-GENERATED DOCUMENTATION AND CLASS
  */
 @javax.annotation.Generated("by GAPIC protoc plugin")
 public class ArchiveName implements ResourceName {
+  
+  @Deprecated
+  protected ArchiveName() { }
 
-  private static final PathTemplate PATH_TEMPLATE =
+  private static final PathTemplate PROJECT_LOCATION_ARCHIVE_PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("projects/{project}/locations/{location}/archives/{archive}");
+  private static final PathTemplate ORGANIZATION_ARCHIVE_PATH_TEMPLATE =
+      PathTemplate.createWithoutUrlEncoding("organizations/{organization}/archives/{archive}");
 
   private volatile Map<String, String> fieldValuesMap;
+  private PathTemplate pathTemplate;
+  private String fixedValue;
 
-  private final String project;
-  private final String location;
-  private final String archive;
+  private String project;
+  private String location;
+  private String archive;
+  private String organization;
 
   public String getProject() {
     return project;
@@ -49,47 +60,110 @@ public class ArchiveName implements ResourceName {
     return archive;
   }
 
-  public static Builder newBuilder() {
-    return new Builder();
+  public String getOrganization() {
+    return organization;
   }
 
-  public Builder toBuilder() {
-    return new Builder(this);
-  }
 
   private ArchiveName(Builder builder) {
     project = Preconditions.checkNotNull(builder.getProject());
     location = Preconditions.checkNotNull(builder.getLocation());
     archive = Preconditions.checkNotNull(builder.getArchive());
+    pathTemplate = PROJECT_LOCATION_ARCHIVE_PATH_TEMPLATE;
   }
 
+  private ArchiveName(OrganizationArchiveBuilder builder) {
+    organization = Preconditions.checkNotNull(builder.getOrganization());
+    archive = Preconditions.checkNotNull(builder.getArchive());
+    pathTemplate = ORGANIZATION_ARCHIVE_PATH_TEMPLATE;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static Builder newProjectLocationArchiveBuilder() {
+    return new Builder();
+  }
+
+  public static OrganizationArchiveBuilder newOrganizationArchiveBuilder() {
+    return new OrganizationArchiveBuilder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+  
   public static ArchiveName of(String project, String location, String archive) {
-    return newBuilder()
-      .setProject(project)
-      .setLocation(location)
-      .setArchive(archive)
-      .build();
+    return newProjectLocationArchiveBuilder()
+        .setProject(project)
+        .setLocation(location)
+        .setArchive(archive)
+        .build();
+  }
+
+  public static ArchiveName ofProjectLocationArchiveName(String project, String location, String archive) {
+    return newProjectLocationArchiveBuilder()
+        .setProject(project)
+        .setLocation(location)
+        .setArchive(archive)
+        .build();
+  }
+
+  public static ArchiveName ofOrganizationArchiveName(String organization, String archive) {
+    return newOrganizationArchiveBuilder()
+        .setOrganization(organization)
+        .setArchive(archive)
+        .build();
   }
 
   public static String format(String project, String location, String archive) {
     return newBuilder()
-      .setProject(project)
-      .setLocation(location)
-      .setArchive(archive)
-      .build()
-      .toString();
+        .setProject(project)
+        .setLocation(location)
+        .setArchive(archive)
+        .build()
+        .toString();
+  }
+
+  public static String formatProjectLocationArchiveName(String project, String location, String archive) {
+    return newBuilder()
+        .setProject(project)
+        .setLocation(location)
+        .setArchive(archive)
+        .build()
+        .toString();
+  }
+
+  public static String formatOrganizationArchiveName(String organization, String archive) {
+    return newOrganizationArchiveBuilder()
+        .setOrganization(organization)
+        .setArchive(archive)
+        .build()
+        .toString();
   }
 
   public static ArchiveName parse(String formattedString) {
     if (formattedString.isEmpty()) {
       return null;
     }
-    Map<String, String> matchMap =
-        PATH_TEMPLATE.validatedMatch(formattedString, "ArchiveName.parse: formattedString not in valid format");
-    return of(matchMap.get("project"), matchMap.get("location"), matchMap.get("archive"));
+    if (PROJECT_LOCATION_ARCHIVE_PATH_TEMPLATE.matches(formattedString)) {
+      Map<String, String> matchMap = PROJECT_LOCATION_ARCHIVE_PATH_TEMPLATE.match(formattedString);
+      return ofProjectLocationArchiveName(
+          matchMap.get("project"), 
+          matchMap.get("location"), 
+          matchMap.get("archive"));
+    } else if (ORGANIZATION_ARCHIVE_PATH_TEMPLATE.matches(formattedString)) {
+      Map<String, String> matchMap = ORGANIZATION_ARCHIVE_PATH_TEMPLATE.match(formattedString);
+      return ofOrganizationArchiveName(
+          matchMap.get("organization"), 
+          matchMap.get("archive"));
+    }
+    throw new ValidationException("JobName.parse: formattedString not in valid format");
   }
 
-  public static List<ArchiveName> parseList(List<String> formattedStrings) {
+  @BetaApi("The method will be renamed to parseList after subclasses of this class are removed.")
+  public static List<ArchiveName> parse(List<String> formattedStrings) {
     List<ArchiveName> list = new ArrayList<>(formattedStrings.size());
     for (String formattedString : formattedStrings) {
       list.add(parse(formattedString));
@@ -97,8 +171,9 @@ public class ArchiveName implements ResourceName {
     return list;
   }
 
-  public static List<String> toStringList(List<ArchiveName> values) {
-    List<String> list = new ArrayList<String>(values.size());
+  @BetaApi("The method will be renamed to toStringList after subclasses of this class are removed.")
+  public static List<String> toStrings(List<ArchiveName> values) {
+    List<String> list = new ArrayList<>(values.size());
     for (ArchiveName value : values) {
       if (value == null) {
         list.add("");
@@ -110,17 +185,28 @@ public class ArchiveName implements ResourceName {
   }
 
   public static boolean isParsableFrom(String formattedString) {
-    return PATH_TEMPLATE.matches(formattedString);
+    return PROJECT_LOCATION_ARCHIVE_PATH_TEMPLATE.matches(formattedString)    
+        || ORGANIZATION_ARCHIVE_PATH_TEMPLATE.matches(formattedString);
   }
-
+  
+  @Override
   public Map<String, String> getFieldValuesMap() {
     if (fieldValuesMap == null) {
       synchronized (this) {
         if (fieldValuesMap == null) {
           ImmutableMap.Builder<String, String> fieldMapBuilder = ImmutableMap.builder();
-          fieldMapBuilder.put("project", project);
-          fieldMapBuilder.put("location", location);
-          fieldMapBuilder.put("archive", archive);
+          if (project != null) {
+            fieldMapBuilder.put("project", project);
+          }
+          if (location != null) {
+            fieldMapBuilder.put("location", location);
+          }
+          if (archive != null) {
+            fieldMapBuilder.put("archive", archive);
+          }
+          if (organization != null) {
+            fieldMapBuilder.put("organization", organization);
+          }
           fieldValuesMap = fieldMapBuilder.build();
         }
       }
@@ -134,15 +220,17 @@ public class ArchiveName implements ResourceName {
 
   @Override
   public String toString() {
-    return PATH_TEMPLATE.instantiate("project", project, "location", location, "archive", archive);
+    return fixedValue != null ? fixedValue : pathTemplate.instantiate(getFieldValuesMap());
   }
 
-  /** Builder for ArchiveName. */
+  /** Builder for projects/{project}/locations/{location}/archives/{archive}. */
   public static class Builder {
 
     private String project;
     private String location;
     private String archive;
+
+    protected Builder() { }
 
     public String getProject() {
       return project;
@@ -171,13 +259,45 @@ public class ArchiveName implements ResourceName {
       return this;
     }
 
-    private Builder() {
-    }
-
     private Builder(ArchiveName archiveName) {
+        Preconditions.checkArgument(
+            archiveName.pathTemplate == PROJECT_LOCATION_ARCHIVE_PATH_TEMPLATE,
+            "toBuilder is only supported when ArchiveName has the pattern of "
+            + "projects/{project}/locations/{location}/archives/{archive}.");
       project = archiveName.project;
       location = archiveName.location;
       archive = archiveName.archive;
+    }
+
+    public ArchiveName build() {
+      return new ArchiveName(this);
+    }
+  }
+
+  /** Builder for organizations/{organization}/archives/{archive}. */
+  public static class OrganizationArchiveBuilder {
+
+    private String organization;
+    private String archive;
+
+    private OrganizationArchiveBuilder() { }
+
+    public String getOrganization() {
+      return organization;
+    }
+
+    public String getArchive() {
+      return archive;
+    }
+
+    public OrganizationArchiveBuilder setOrganization(String organization) {
+      this.organization = organization;
+      return this;
+    }
+
+    public OrganizationArchiveBuilder setArchive(String archive) {
+      this.archive = archive;
+      return this;
     }
 
     public ArchiveName build() {
@@ -190,11 +310,12 @@ public class ArchiveName implements ResourceName {
     if (o == this) {
       return true;
     }
-    if (o instanceof ArchiveName) {
+    if (o == null || getClass() != o.getClass()) {
       ArchiveName that = (ArchiveName) o;
-      return (this.project.equals(that.project))
-          && (this.location.equals(that.location))
-          && (this.archive.equals(that.archive));
+      return (Objects.equals(this.project, that.project))
+          && (Objects.equals(this.location, that.location))
+          && (Objects.equals(this.archive, that.archive))
+          && (Objects.equals(this.organization, that.organization));
     }
     return false;
   }
@@ -203,12 +324,15 @@ public class ArchiveName implements ResourceName {
   public int hashCode() {
     int h = 1;
     h *= 1000003;
-    h ^= project.hashCode();
+    h ^= Objects.hashCode(fixedValue);
     h *= 1000003;
-    h ^= location.hashCode();
+    h ^= Objects.hashCode(project);
     h *= 1000003;
-    h ^= archive.hashCode();
+    h ^= Objects.hashCode(location);
+    h *= 1000003;
+    h ^= Objects.hashCode(archive);
+    h *= 1000003;
+    h ^= Objects.hashCode(organization);
     return h;
   }
 }
-

--- a/test/testdata/protoannotation/java_archive_names.baseline
+++ b/test/testdata/protoannotation/java_archive_names.baseline
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.example.library.v1;
+
+import com.google.api.resourcenames.ResourceName;
+
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ *
+ * @deprecated This resource name class will be removed in the next major version.
+ */
+@javax.annotation.Generated("by GAPIC protoc plugin")
+@Deprecated
+public class ArchiveNames {
+  private ArchiveNames() {}
+
+  public static ArchiveName parse(String resourceNameString) {
+    return UntypedArchiveName.parse(resourceNameString);
+  }
+}

--- a/test/testdata/protoannotation/java_organization_name.baseline
+++ b/test/testdata/protoannotation/java_organization_name.baseline
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.example.library.v1;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.api.pathtemplate.PathTemplate;
+import com.google.api.resourcenames.ResourceName;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ */
+@javax.annotation.Generated("by GAPIC protoc plugin")
+public class OrganizationName implements ResourceName {
+
+  private static final PathTemplate PATH_TEMPLATE =
+      PathTemplate.createWithoutUrlEncoding("organizations/{organization}");
+
+  private volatile Map<String, String> fieldValuesMap;
+
+  private final String organization;
+
+  public String getOrganization() {
+    return organization;
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  private OrganizationName(Builder builder) {
+    organization = Preconditions.checkNotNull(builder.getOrganization());
+  }
+
+  public static OrganizationName of(String organization) {
+    return newBuilder()
+      .setOrganization(organization)
+      .build();
+  }
+
+  public static String format(String organization) {
+    return newBuilder()
+      .setOrganization(organization)
+      .build()
+      .toString();
+  }
+
+  public static OrganizationName parse(String formattedString) {
+    if (formattedString.isEmpty()) {
+      return null;
+    }
+    Map<String, String> matchMap =
+        PATH_TEMPLATE.validatedMatch(formattedString, "OrganizationName.parse: formattedString not in valid format");
+    return of(matchMap.get("organization"));
+  }
+
+  public static List<OrganizationName> parseList(List<String> formattedStrings) {
+    List<OrganizationName> list = new ArrayList<>(formattedStrings.size());
+    for (String formattedString : formattedStrings) {
+      list.add(parse(formattedString));
+    }
+    return list;
+  }
+
+  public static List<String> toStringList(List<OrganizationName> values) {
+    List<String> list = new ArrayList<String>(values.size());
+    for (OrganizationName value : values) {
+      if (value == null) {
+        list.add("");
+      } else {
+        list.add(value.toString());
+      }
+    }
+    return list;
+  }
+
+  public static boolean isParsableFrom(String formattedString) {
+    return PATH_TEMPLATE.matches(formattedString);
+  }
+
+  public Map<String, String> getFieldValuesMap() {
+    if (fieldValuesMap == null) {
+      synchronized (this) {
+        if (fieldValuesMap == null) {
+          ImmutableMap.Builder<String, String> fieldMapBuilder = ImmutableMap.builder();
+          fieldMapBuilder.put("organization", organization);
+          fieldValuesMap = fieldMapBuilder.build();
+        }
+      }
+    }
+    return fieldValuesMap;
+  }
+
+  public String getFieldValue(String fieldName) {
+    return getFieldValuesMap().get(fieldName);
+  }
+
+  @Override
+  public String toString() {
+    return PATH_TEMPLATE.instantiate("organization", organization);
+  }
+
+  /** Builder for OrganizationName. */
+  public static class Builder {
+
+    private String organization;
+
+    public String getOrganization() {
+      return organization;
+    }
+
+    public Builder setOrganization(String organization) {
+      this.organization = organization;
+      return this;
+    }
+
+    private Builder() {
+    }
+
+    private Builder(OrganizationName organizationName) {
+      organization = organizationName.organization;
+    }
+
+    public OrganizationName build() {
+      return new OrganizationName(this);
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof OrganizationName) {
+      OrganizationName that = (OrganizationName) o;
+      return (this.organization.equals(that.organization));
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 1;
+    h *= 1000003;
+    h ^= organization.hashCode();
+    return h;
+  }
+}
+

--- a/test/testdata/protoannotation/java_untyped_archive_name.baseline
+++ b/test/testdata/protoannotation/java_untyped_archive_name.baseline
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.example.library.v1;
+
+import com.google.common.base.Preconditions;
+import com.google.api.resourcenames.ResourceName;
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AUTO-GENERATED DOCUMENTATION AND CLASS
+ *
+ * @deprecated This resource name class will be removed in the next major version.
+ */
+@javax.annotation.Generated("by GAPIC protoc plugin")
+@Deprecated
+public class UntypedArchiveName extends ArchiveName {
+
+  private final String rawValue;
+  private Map<String, String> valueMap;
+
+  private UntypedArchiveName(String rawValue) {
+    this.rawValue = Preconditions.checkNotNull(rawValue);
+    this.valueMap = ImmutableMap.of("", rawValue);
+  }
+
+  public static UntypedArchiveName from(ResourceName resourceName) {
+    return new UntypedArchiveName(resourceName.toString());
+  }
+
+  public static UntypedArchiveName parse(String formattedString) {
+    return new UntypedArchiveName(formattedString);
+  }
+
+  public static List<UntypedArchiveName> parseList(List<String> formattedStrings) {
+    List<UntypedArchiveName> list = new ArrayList<>(formattedStrings.size());
+    for (String formattedString : formattedStrings) {
+      list.add(parse(formattedString));
+    }
+    return list;
+  }
+
+  public static List<String> toStringList(List<UntypedArchiveName> values) {
+    List<String> list = new ArrayList<String>(values.size());
+    for (UntypedArchiveName value : values) {
+      if (value == null) {
+        list.add("");
+      } else {
+        list.add(value.toString());
+      }
+    }
+    return list;
+  }
+
+  public static boolean isParsableFrom(String formattedString) {
+    return true;
+  }
+
+  /**
+   * Return a map with a single value rawValue keyed on an empty String "".
+   */
+  public Map<String, String> getFieldValuesMap() {
+    return valueMap;
+  }
+
+  /**
+   * Return the initial rawValue if @param fieldName is an empty String, else return null.
+   */
+  public String getFieldValue(String fieldName) {
+    return valueMap.get(fieldName);
+  }
+
+  @Override
+  public String toString() {
+    return rawValue;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof UntypedArchiveName) {
+      UntypedArchiveName that = (UntypedArchiveName) o;
+      return this.rawValue.equals(that.rawValue);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return rawValue.hashCode();
+  }
+}


### PR DESCRIPTION
In cases such as:

```proto
message ListFoosRequest {
  string parent = 1 [
    (google.api.resource_reference).child_type = "foo.googleapis.com/Foo"];
}

message Foo {
  option (google.api.resource) = {
    type: "foo.googleapis.com/Foo",
    pattern: "projects/{project}/foos/{foo}",
    pattern: "projects/{project}/locations/{location}"
  };

  string name = 1;
}
```

We should generate both `ProjectName` and `LocationName`.