### PR TITLE
fix: stop generating `parseList` and `toStringList` if a multi-pattern resource name has subclasses

### DIFF
--- a/plugin/templates/multi_pattern_resource_name.mustache
+++ b/plugin/templates/multi_pattern_resource_name.mustache
@@ -158,8 +158,8 @@ public class {{class_name}} implements ResourceName {
     throw new ValidationException("JobName.parse: formattedString not in valid format");
   }
 
-  @BetaApi("The method will be renamed to parseList after subclasses of this class are removed.")
-  public static List<{{class_name}}> parse(List<String> formattedStrings) {
+  {{#has_no_single_pattern_subclasses}}
+  public static List<{{class_name}}> parseList(List<String> formattedStrings) {
     List<{{class_name}}> list = new ArrayList<>(formattedStrings.size());
     for (String formattedString : formattedStrings) {
       list.add(parse(formattedString));
@@ -167,8 +167,7 @@ public class {{class_name}} implements ResourceName {
     return list;
   }
 
-  @BetaApi("The method will be renamed to toStringList after subclasses of this class are removed.")
-  public static List<String> toStrings(List<{{class_name}}> values) {
+  public static List<String> toStringList(List<{{class_name}}> values) {
     List<String> list = new ArrayList<>(values.size());
     for ({{class_name}} value : values) {
       if (value == null) {
@@ -179,6 +178,7 @@ public class {{class_name}} implements ResourceName {
     }
     return list;
   }
+  {{/has_no_single_pattern_subclasses}}
 
   public static boolean isParsableFrom(String formattedString) {
     return {{#patterns}}{{#is_formattable}}{{upper_underscore}}_PATH_TEMPLATE.matches(formattedString){{/is_formattable}}{{#is_fixed}}{{upper_underscore}}_FIXED_VALUE.equals(formattedString){{/is_fixed}}{{#not_last}}    

--- a/plugin/templates/resource_name.py
+++ b/plugin/templates/resource_name.py
@@ -152,6 +152,9 @@ class ParentResourceName(ResourceNameBase):
                                     segment_to_segment_symbols))
             for pattern in pattern_strings]
 
+        self.has_no_single_pattern_subclasses = \
+            not oneof.has_deprecated_collections
+
         if len(self.patterns) > 0:
             self.first_pattern = self.patterns[0]
             self.patterns[0].set_first()

--- a/plugin/utils/gapic_utils.py
+++ b/plugin/utils/gapic_utils.py
@@ -189,7 +189,7 @@ def create_gapic_config_v2(gapic_v2, request):  # noqa: C901
 
     update_collections_with_deprecated_resources(
         gapic_v2,
-        pattern_resource_map, 
+        pattern_resource_map,
         collection_oneofs)
 
     single_resource_names, fixed_resource_names = \
@@ -414,9 +414,7 @@ def update_collections_with_deprecated_resources(
                 raise ValueError('name_pattern is required '
                                  'in a deprecated_collection.')
 
-            entity_name = deprecated_collection['entity_name']
             name_pattern = deprecated_collection['name_pattern']
-
             if name_pattern not in pattern_resource_map:
                 raise ValueError(
                     'deprecated collection has '
@@ -434,6 +432,7 @@ def update_collections_with_deprecated_resources(
             # This field is here to turn off generating `parseList`
             # and `toStringList` methods to avoid naming collisions.
             collection_oneofs[oneof_name]['has_deprecated_collections'] = True
+
 
 def build_parent_patterns(patterns):
     def _parent_pattern(pattern):

--- a/plugin/utils/gapic_utils.py
+++ b/plugin/utils/gapic_utils.py
@@ -187,6 +187,11 @@ def create_gapic_config_v2(gapic_v2, request):  # noqa: C901
             if res.type:
                 update_collections(res, collections, collection_oneofs)
 
+    update_collections_with_deprecated_resources(
+        gapic_v2,
+        pattern_resource_map, 
+        collection_oneofs)
+
     single_resource_names, fixed_resource_names = \
         find_single_and_fixed_entities(collections.values())
 
@@ -368,6 +373,68 @@ def update_collections(res, collections, collection_oneofs):
     # pylint: enable=no-member
 
 
+def _get_resource_for_deprecate_pattern(
+        deprecated_collection_pattern,
+        pattern_resource_map):
+    resources = pattern_resource_map[deprecated_collection_pattern]
+    resources = [r for r in resources if len(r.pattern) > 1]
+
+    # A deprecated collection pattern belonging to multiple resources
+    # is very unlikely and cannot be nicely handled by resource
+    # name design in GAPIC v1(as the parent resource class is an
+    # abstract class rather than an interface, and Java does not
+    # have multiple inheritence).
+    if len(resources) > 1:
+        raise ValueError('Not supported: pattern of a deprecated '
+                         'collections belongs to multiple resources: '
+                         '{}'.format(deprecated_collection_pattern))
+    if not resources:
+        raise ValueError('Not supported: deprecating a single-pattern'
+                         'resource name.')
+    resource = resources[0]
+    if len(resource.pattern) <= 1:
+        raise ValueError('deprecated collection point to a '
+                         'single-pattern resource: {}'.format(
+                             resource.type))
+    return resource
+
+
+def update_collections_with_deprecated_resources(
+        gapic_v2,
+        pattern_resource_map,
+        collection_oneofs):
+    for interface in gapic_v2.get('interfaces', ()):
+        if 'deprecated_collections' not in interface:
+            continue
+        for deprecated_collection in interface['deprecated_collections']:
+            if 'entity_name' not in deprecated_collection:
+                raise ValueError('entity_name is required '
+                                 'in a deprecated_collection.')
+            if 'name_pattern' not in deprecated_collection:
+                raise ValueError('name_pattern is required '
+                                 'in a deprecated_collection.')
+
+            entity_name = deprecated_collection['entity_name']
+            name_pattern = deprecated_collection['name_pattern']
+
+            if name_pattern not in pattern_resource_map:
+                raise ValueError(
+                    'deprecated collection has '
+                    'an unknown name pattern: {}'.format(name_pattern))
+
+            resource = _get_resource_for_deprecate_pattern(
+                name_pattern, pattern_resource_map)
+            oneof_name = to_snake(resource.type.split('/')[-1]) + '_oneof'
+            if oneof_name not in collection_oneofs:
+                raise ValueError(
+                    'internal: multi-pattern resource not added to '
+                    'collection_oneofs: {}'.format(oneof_name))
+            # Note Gapic config does not actually have the
+            # `has_deprecated_collections` field.
+            # This field is here to turn off generating `parseList`
+            # and `toStringList` methods to avoid naming collisions.
+            collection_oneofs[oneof_name]['has_deprecated_collections'] = True
+
 def build_parent_patterns(patterns):
     def _parent_pattern(pattern):
         segs = pattern.split('/')
@@ -485,9 +552,12 @@ def load_collection_oneofs(config_list, existing_collections,
         pattern_strings = []
         if 'pattern_strings' in config:
             pattern_strings = config['pattern_strings']
+        has_deprecated_collections = False
+        if 'has_deprecated_collections' in config:
+            has_deprecated_collections = config['has_deprecated_collections']
         existing_oneofs[root_type_name] = CollectionOneof(
             root_type_name, resources, fixed_resources, collection_names,
-            pattern_strings)
+            pattern_strings, has_deprecated_collections)
     return existing_oneofs
 
 
@@ -558,12 +628,14 @@ class FixedCollectionConfig(object):
 class CollectionOneof(object):
 
     def __init__(self, oneof_name, legacy_resources, legacy_fixed_resources,
-                 legacy_collection_names, pattern_strings):
+                 legacy_collection_names, pattern_strings,
+                 has_deprecated_collections):
         self.oneof_name = oneof_name
         self.legacy_resource_list = legacy_resources
         self.legacy_fixed_resource_list = legacy_fixed_resources
         self.legacy_collection_names = legacy_collection_names
         self.pattern_strings = pattern_strings
+        self.has_deprecated_collections = has_deprecated_collections
 
 
 class GapicConfig(object):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')
     sys.exit()
 
-version = '0.0.23'
+version = '0.0.24'
 
 install_requires = [
     'chevron >= 0.13.1',

--- a/test/test_gapic_utils.py
+++ b/test/test_gapic_utils.py
@@ -208,26 +208,13 @@ def test_update_collections_with_deprecated_collections():
     }
 
     gapic_utils.update_collections_with_deprecated_resources(
-        gapic_v2, pattern_map, collections, collection_oneofs)
+        gapic_v2, pattern_map, collection_oneofs)
 
     assert collection_oneofs == {
         'book_oneof': {
             'oneof_name': 'book_oneof',
-            'collection_names': [
-                'some_archive_book', 'my_shelf_book']
-        }
-    }
-    assert collections == {
-        'some_archive_book': {
-            'entity_name': 'some_archive_book',
-            'name_pattern': "archives/{archive}/books/{book}"
-        },
-        'my_shelf_book': {
-            'entity_name': 'my_shelf_book',
-            'name_pattern': "shelves/{shelf}/books/{book}",
-            'language_overrides': [
-                {'language': 'java',
-                 'entity_name': 'shelf_book'}]
+            'collection_names': [],
+            'has_deprecated_collections': True
         }
     }
 
@@ -316,25 +303,9 @@ def test_library_gapic_v2():
             gapic_config, "com.google.example.library.v1")
     assert [r for r in resource_name_artifacts if
             type(r) is resource_name.ResourceName
-            and r.format_string ==
-            'projects/{project}/shelves/{shelf}/books/{book}'
-            and r.format_name_lower == 'shelfBookName'
-            and r.parent_interface == 'BookName']
-    assert [r for r in resource_name_artifacts if
-            type(r) is resource_name.ResourceName
-            and r.format_string == 'archives/{archive}/books/{book}'
-            and r.format_name_lower == 'archivedBookName'
-            and r.parent_interface == 'BookName']
-    assert [r for r in resource_name_artifacts if
-            type(r) is resource_name.ResourceName
             and r.format_string == 'projects/{project}/shelves/{shelf}'
             and r.format_name_lower == 'shelfName'
             and r.parent_interface == 'ResourceName']
-    assert [r for r in resource_name_artifacts if
-            type(r) is resource_name.ResourceNameFixed
-            and r.fixed_value == '_deleted-book_'
-            and r.class_name == 'DeletedBook'
-            and r.parent_interface == 'BookName']
 
     assert [r for r in resource_name_artifacts if
             type(r) is resource_name.ParentResourceName
@@ -351,6 +322,3 @@ def test_library_gapic_v2():
     assert [r for r in resource_name_artifacts if
             type(r) is resource_name.ParentResourceName
             and r.class_name == 'BookName']
-    assert [r for r in resource_name_artifacts if
-            type(r) is resource_name.ResourceNameFactory
-            and r.class_name == 'BookNames']

--- a/test/test_gapic_utils.py
+++ b/test/test_gapic_utils.py
@@ -201,7 +201,6 @@ def test_update_collections_with_deprecated_collections():
             'collection_names': []
         }
     }
-    collections = {}
     pattern_map = {
         "archives/{archive}/books/{book}": [book],
         "shelves/{shelf}/books/{book}": [book]

--- a/test/testdata/protoannotation/java_archive_name.baseline
+++ b/test/testdata/protoannotation/java_archive_name.baseline
@@ -168,8 +168,7 @@ public class ArchiveName implements ResourceName {
     throw new ValidationException("JobName.parse: formattedString not in valid format");
   }
 
-  @BetaApi("The method will be renamed to parseList after subclasses of this class are removed.")
-  public static List<ArchiveName> parse(List<String> formattedStrings) {
+  public static List<ArchiveName> parseList(List<String> formattedStrings) {
     List<ArchiveName> list = new ArrayList<>(formattedStrings.size());
     for (String formattedString : formattedStrings) {
       list.add(parse(formattedString));
@@ -177,8 +176,7 @@ public class ArchiveName implements ResourceName {
     return list;
   }
 
-  @BetaApi("The method will be renamed to toStringList after subclasses of this class are removed.")
-  public static List<String> toStrings(List<ArchiveName> values) {
+  public static List<String> toStringList(List<ArchiveName> values) {
     List<String> list = new ArrayList<>(values.size());
     for (ArchiveName value : values) {
       if (value == null) {

--- a/test/testdata/protoannotation/java_book_name.baseline
+++ b/test/testdata/protoannotation/java_book_name.baseline
@@ -189,27 +189,6 @@ public class BookName implements ResourceName {
     throw new ValidationException("JobName.parse: formattedString not in valid format");
   }
 
-  @BetaApi("The method will be renamed to parseList after subclasses of this class are removed.")
-  public static List<BookName> parse(List<String> formattedStrings) {
-    List<BookName> list = new ArrayList<>(formattedStrings.size());
-    for (String formattedString : formattedStrings) {
-      list.add(parse(formattedString));
-    }
-    return list;
-  }
-
-  @BetaApi("The method will be renamed to toStringList after subclasses of this class are removed.")
-  public static List<String> toStrings(List<BookName> values) {
-    List<String> list = new ArrayList<>(values.size());
-    for (BookName value : values) {
-      if (value == null) {
-        list.add("");
-      } else {
-        list.add(value.toString());
-      }
-    }
-    return list;
-  }
 
   public static boolean isParsableFrom(String formattedString) {
     return PROJECT_SHELF_BOOK_PATH_TEMPLATE.matches(formattedString)    


### PR DESCRIPTION
In Java, parent classes and child classes cannot have methods with the same signature if the methods:
1. both have generic types in parameters or return type
2. the methods have the same type eraser.

The rule affects libraries migrated from gapic config. We used to generate super-class and subclass for multi-pattern resource names for these libraries and we need to continue to do so for backward-compatibility. Therefore we do not generate `toStringList` and `parseList` on the surface of the new multi-pattern resource names if a library is converted from gapic config.

We check if a resource is carried over from gapic v1 by checking whether there is a `deprecated_collection` that matches one of its patterns in gapic v2.
