### PR TITLE
chore: remove Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 sudo: false
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 before_script:


### PR DESCRIPTION
It's been EOL for 1 year and has been causing more and more dependency problems as libraries start to not support it.