### PR TITLE
[java-resnames] fix: update protobuf version in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,9 +54,9 @@ jobs:
         name: Install protoc.
         command: |
           mkdir -p /usr/src/protoc/
-          curl --location https://github.com/google/protobuf/releases/download/v3.11.2/protoc-3.11.2-linux-x86_64.zip --output /usr/src/protoc/protoc-3.11.2.zip
+          curl --location https://github.com/google/protobuf/releases/download/v3.12.3/protoc-3.12.3-linux-x86_64.zip --output /usr/src/protoc/protoc-3.12.3.zip
           cd /usr/src/protoc/
-          unzip protoc-3.11.2.zip
+          unzip protoc-3.12.3.zip
           ln -s /usr/src/protoc/bin/protoc /bin/protoc
     - run:
         name: Run tests.


### PR DESCRIPTION
Update the protobuf version in CircleCI to get the latest proto3 field presence features.